### PR TITLE
fix `make deb` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null) 
+GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 VERSION?=1.1.0
 TAG?=v$(VERSION)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep 'refs/tags/$(TAG)$$' | awk '{print $$1}')


### PR DESCRIPTION
some change snuck into #1 which broke `make deb` target

without this PR (see the docker image has extra space):
```
$ make -n deb | head -1
docker build --build-arg GOARCH="amd64 " --build-arg GOVERSION="1.10.1" --build-arg TAG="v1.1.0" --build-arg REF="38e4e4f4df10c1ee0f754bf43a79c6a12d055a65" -f dockerfiles/ubuntu-xenial.dockerfile -t containerd-builder-ubuntu-xenial-amd64 :v1.1.0 .
```

with this PR:
```
$ make -n deb | head -1
docker build --build-arg GOARCH="amd64" --build-arg GOVERSION="1.10.1" --build-arg TAG="v1.1.0" --build-arg REF="38e4e4f4df10c1ee0f754bf43a79c6a12d055a65" -f dockerfiles/ubuntu-xenial.dockerfile -t containerd-builder-ubuntu-xenial-amd64:v1.1.0 .
```