### PR TITLE
Switch to using containerd build rigging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,8 @@ Maintainer: Containerd team <help@containerd.io>
 Build-Depends: btrfs-tools,
                debhelper,
                dh-systemd,
-               pkg-config
+               pkg-config,
+               libseccomp-dev
 Standards-Version: 4.1.4
 Homepage: https://containerd.io
 Vcs-Browser: https://github.com/containerd/containerd

--- a/debian/rules
+++ b/debian/rules
@@ -1,18 +1,15 @@
 #!/usr/bin/make -f
 
-# IMPORT_PATH and GO_SRC_PATH are defined in the dockerfile
-# VERSION and REF are defined in scripts/build-deb
-LDFLAGS=-X $${IMPORT_PATH}/version.Package=$${IMPORT_PATH} -X $${IMPORT_PATH}/version.Version=$${VERSION} -X $${IMPORT_PATH}/version.Revision=$${REF}
-GO_BUILD=go build -ldflags "$(LDFLAGS) -B 0x$$(head -c20 /dev/urandom|od -An -tx1 |tr -d ' \n')" -a
 INSTALL_DIR=debian/containerd
 
 %:
 	dh $@ --with systemd
 
+# GO_SRC_PATH are defined in the dockerfile
+# VERSION and REF are defined in scripts/build-deb
 bin/%: ## Create containerd binaries
-	@mkdir -p bin/
-	@echo "$(GO_BUILD) -o $@ $${IMPORT_PATH}/cmd/$*"
-	@$(GO_BUILD) -o $@ $${IMPORT_PATH}/cmd/$*
+	@echo "+ make -C $(GO_SRC_PATH) --no-print-directory VERSION=$${VERSION} REVISION=$${REF} $@"
+	@make -C $(GO_SRC_PATH) --no-print-directory VERSION=$${VERSION} REVISION=$${REF} $@
 
 override_dh_auto_build: bin/containerd bin/containerd-shim bin/ctr
 
@@ -20,7 +17,7 @@ override_dh_auto_install: bin/containerd bin/containerd-shim bin/ctr
 	# set -x so we can see what's being installed where
 	for binary in $^; do \
 		dest=$$(basename $$binary); \
-		(set -x; install -D -m 0755 $$binary $(INSTALL_DIR)/usr/bin/$$dest); \
+		(set -x; install -D -m 0755 $(GO_SRC_PATH)/$$binary $(INSTALL_DIR)/usr/bin/$$dest); \
 	done
 	install -D -m 0644 /root/common/containerd.service $(INSTALL_DIR)/lib/systemd/system/containerd.service
 	install -D -m 0644 /root/common/containerd.toml $(INSTALL_DIR)/etc/containerd/config.toml

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -6,7 +6,6 @@ RUN yum groupinstall -y "Development Tools"
 RUN yum remove -y git
 RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm epel-release
 RUN yum install -y \
-   btrfs-progs-devel \
    pkgconfig \
    tar \
    cmake \

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -23,10 +23,6 @@ AutoReq: no
 %global debug_package %{nil}
 %endif
 
-%if ! 0%{?gobuild:1}
-%define gobuild(o:) go build -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n')" -a -x %{?**};
-%endif
-
 %define SHA256SUM0 08f057ece7e518b14cce2e9737228a5a899a7b58b78248a03e02f4a6c079eeaf
 %global import_path github.com/containerd/containerd
 %global gopath %{getenv:GOPATH}
@@ -42,6 +38,7 @@ Source1: containerd.service
 Source2: containerd.toml
 BuildRequires: systemd
 BuildRequires: btrfs-progs-devel
+BuildRequires: libseccomp-devel
 %{?systemd_requires}
 # https://github.com/containerd/containerd/issues/1508#issuecomment-335566293
 Requires: runc >= 1.0.0
@@ -69,10 +66,10 @@ cd %{_topdir}/BUILD
 go get -u github.com/cpuguy83/go-md2man
 make man
 
-export LDFLAGS="-X %{import_path}/version.Package=%{import_path} -X %{import_path}/version.Version=%{getenv:VERSION} -X %{import_path}/version.Revision=%{getenv:REF}"
-%gobuild -o bin/containerd %{import_path}/cmd/containerd
-%gobuild -o bin/containerd-shim %{import_path}/cmd/containerd-shim
-%gobuild -o bin/ctr %{import_path}/cmd/ctr
+%define make_containerd(o:) make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} %{?**};
+%make_containerd bin/containerd
+%make_containerd bin/containerd-shim
+%make_containerd bin/ctr
 
 
 %install

--- a/scripts/build-rpm
+++ b/scripts/build-rpm
@@ -25,4 +25,4 @@ export RPM_RELEASE_VERSION
 export RPM_VERSION
 export VERSION
 
-(set -x; rpmbuild -ba SPECS/containerd.spec)
+(set -x; yum-builddep -y SPECS/containerd.spec; rpmbuild -ba SPECS/containerd.spec)


### PR DESCRIPTION
Uses the containerd Makefile to actually make the binaries instead of
relying on our own hacky `go build`

Addresses #14 (hopefully)

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>