### PR TITLE
Add architecture to build directory

### DIFF
--- a/scripts/build-deb
+++ b/scripts/build-deb
@@ -25,5 +25,7 @@ REF=$(git -C "${GO_SRC_PATH}" rev-parse HEAD)
 export REF
 export VERSION
 (set -x; dpkg-buildpackage -uc -us)
-mv -v ../*.deb /out
-mv -v ../*.changes /out
+OUT_DIR="/out/$(dpkg --print-architecture)"
+mkdir -p "${OUT_DIR}"
+mv -v ../*.deb "${OUT_DIR}"
+mv -v ../*.changes "${OUT_DIR}"


### PR DESCRIPTION
Going to need it for repo building

Looks like: 
```
❯ find build
build
build/DEB
build/DEB/amd64
build/DEB/amd64/containerd_1.1.0-1_amd64.changes
build/DEB/amd64/containerd_1.1.0-1_amd64.deb
build/SRPMS
build/RPMS
```
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>