### PR TITLE
remove unneeded build deps for rpm

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -1,14 +1,10 @@
 FROM centos:7
 
-RUN yum groupinstall -y "Development Tools"
-
 # Install git (git2u) through the IUS repository since it's more up to date
-RUN yum remove -y git
 RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm epel-release
 RUN yum install -y \
-   pkgconfig \
-   tar \
-   cmake \
+   make \
+   gcc \
    rpm-build \
    git2u
 


### PR DESCRIPTION
Stuff not needed. Build time reduced from 3'09" to 2'10", image size reduced from 1.32G to 0.99G.

Before:
```
$ time make rpm
...
Wrote: /root/rpmbuild/RPMS/x86_64/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.3HY1Ad
+ umask 022
+ cd /root/rpmbuild/BUILD
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64
+ exit 0
docker run --rm -v /home/ubuntu/src/a-containerd-packaging:/v -w /v alpine chown -R 1000:1000 build/
real    3m9.347s
user    0m0.556s
sys     0m0.114s
$ docker images|grep containerd
containerd-builder-rpm-amd64   3a4b667     5ec584a3f198    About a minute ago   1.32GB
```

After:
```
$ time make rpm
...
Wrote: /root/rpmbuild/RPMS/x86_64/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.0A73ZT
+ umask 022
+ cd /root/rpmbuild/BUILD
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64
+ exit 0
docker run --rm -v /home/ubuntu/src/a-containerd-packaging:/v -w /v alpine chown -R 1000:1000 build/
real    2m10.603s
user    0m0.508s
sys     0m0.090s
$ docker images|grep containerd
containerd-builder-rpm-amd64   02007ae    9cea7d725c05    About a minute ago   993MB
```