### PR TITLE
move all rpm build deps into spec file

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -3,8 +3,6 @@ FROM centos:7
 # Install git (git2u) through the IUS repository since it's more up to date
 RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm epel-release
 RUN yum install -y \
-   make \
-   gcc \
    rpm-build \
    git2u
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -36,6 +36,8 @@ URL: https://containerd.io
 Source0: containerd
 Source1: containerd.service
 Source2: containerd.toml
+BuildRequires: make
+BuildRequires: gcc
 BuildRequires: systemd
 BuildRequires: btrfs-progs-devel
 BuildRequires: libseccomp-devel


### PR DESCRIPTION
Moving the remaining dependencies for building containerd to within the spec file with the rest of the dependencies defined there.

These deps do not need to be in the `rpm.dockerfile` because there are no `RUN` commands in the dockerfile that use `make` or `gcc`.

No functionality change.

```
$ time make rpm
...
Wrote: /root/rpmbuild/RPMS/x86_64/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.xaMue6
+ umask 022
+ cd /root/rpmbuild/BUILD
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64
+ exit 0
docker run --rm -v /home/ubuntu/src/a-containerd-packaging:/v -w /v alpine chown -R 1000:1000 build/

real    2m11.914s
user    0m0.493s
sys     0m0.128s
$ docker images|grep containerd
containerd-builder-rpm-amd64   62fce8d     7f92ce62a328    About a minute ago   946MB
```