### PR TITLE
move go-md2man to an rpm build dep

### DIFF
--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -39,6 +39,7 @@ Source2: containerd.toml
 BuildRequires: systemd
 BuildRequires: btrfs-progs-devel
 BuildRequires: libseccomp-devel
+BuildRequires: go-md2man
 %{?systemd_requires}
 # https://github.com/containerd/containerd/issues/1508#issuecomment-335566293
 Requires: runc >= 1.0.0
@@ -62,8 +63,6 @@ cd %{_topdir}/BUILD/
 
 %build
 cd %{_topdir}/BUILD
-# needed for man pages
-go get -u github.com/cpuguy83/go-md2man
 make man
 
 pushd /go/src/%{import_path}


### PR DESCRIPTION
No need to go get if it is a build dep.

Stuff still builds:
```
$ time make rpm
...
Wrote: /root/rpmbuild/RPMS/x86_64/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.q3SR2q
+ umask 022
+ cd /root/rpmbuild/BUILD
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64
+ exit 0
docker run --rm -v /home/ubuntu/src/a-containerd-packaging:/v -w /v alpine chown -R 1000:1000 build/
real    2m1.781s
user    0m0.505s
sys     0m0.080s
```