### PR TITLE
refactor rpm build dockerfile for multi stage

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -1,28 +1,29 @@
-FROM centos:7
-
-# Install git (git2u) through the IUS repository since it's more up to date
-RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm epel-release
-RUN yum install -y \
-   rpm-build \
-   git2u
-
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
+FROM alpine:latest as golang
+RUN apk add curl
 ARG GO_DL_URL
 RUN curl -fsSL "${GO_DL_URL}" | tar xzC /usr/local
+
+FROM alpine:latest as containerd
+RUN apk add git
+ARG REF
+RUN git clone https://github.com/containerd/containerd.git /containerd
+RUN git -C /containerd checkout ${REF}
+
+FROM centos:7
+# Install git (git2u) through the IUS repository since it's more up to date
+RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm epel-release
+RUN yum install -y rpm-build git2u
+ARG REF
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
-
+ENV GO_SRC_PATH /go/src/github.com/containerd/containerd
+COPY --from=golang /usr/local/go /usr/local/go/
+COPY --from=containerd /containerd ${GO_SRC_PATH}
 COPY common/containerd.toml /root/rpmbuild/SOURCES/containerd.toml
 COPY common/containerd.service /root/rpmbuild/SOURCES/containerd.service
 COPY rpm/containerd.spec /root/rpmbuild/SPECS/containerd.spec
 COPY scripts/build-rpm /build-rpm
 COPY scripts/.rpm-helpers /.rpm-helpers
-
-RUN mkdir -p /go
-ARG REF
-ENV GO_SRC_PATH /go/src/github.com/containerd/containerd
-RUN git clone https://github.com/containerd/containerd.git ${GO_SRC_PATH}
-RUN git -C ${GO_SRC_PATH} checkout ${REF}
-
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/build-rpm"]


### PR DESCRIPTION
No functionality change. This will allow faster builds with buildkit and docker-ce 18.06.0, reducing time from 2'07" to 1'53".

Before:
```
$ time make rpm
...
Wrote: /root/rpmbuild/RPMS/x86_64/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.kIDSgi
+ umask 022
+ cd /root/rpmbuild/BUILD
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64
+ exit 0
docker run --rm -v /home/ubuntu/src/a-containerd-packaging:/v -w /v alpine chown -R 1000:1000 build/

real    2m7.611s
user    0m0.533s
sys     0m0.085s
```

After:
```
$ time DOCKER_BUILDKIT=1 make rpm
...
Wrote: /root/rpmbuild/RPMS/x86_64/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.Rhn5Ka
+ umask 022
+ cd /root/rpmbuild/BUILD
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/containerd-0.20180720.205417~0d52c71c-0.el7.x86_64
+ exit 0
docker run --rm -v /home/ubuntu/src/a-containerd-packaging:/v -w /v alpine chown -R 1000:1000 build/

real    1m53.997s
user    0m0.735s
sys     0m0.184s
```