### PR TITLE
Add new runc installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+runc.tar

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 REF?=master
+RUNC_REF?=v1.0.0-rc5
+OFFLINE_INSTALL_REF?=20eddbfe5d4d894cfee6974829c7d3981acba1be
 GOVERSION?=1.10.3
 GO_DL_URL?=$(shell GOVERSION=$(GOVERSION) ./scripts/gen-go-dl-url)
 
@@ -7,6 +9,7 @@ BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD
 BUILD=docker build \
 	 --build-arg GO_DL_URL="$(GO_DL_URL)" \
 	 --build-arg REF="$(REF)" \
+	 --build-arg OFFLINE_INSTALL_REF="$(OFFLINE_INSTALL_REF)" \
 	 -f dockerfiles/$@.dockerfile \
 	 -t $(BUILDER_IMAGE) .
 
@@ -22,21 +25,34 @@ RUN=docker run --rm $(VOLUME_MOUNTS) -t $(BUILDER_IMAGE)
 CHOWN=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 CHOWN_TO_USER=$(CHOWN) -R $(shell id -u):$(shell id -g)
 
+# Default to `ctr` if it's around, else use `docker-containerd-ctr`
+CTR=$(shell if which ctr > /dev/null 2>/dev/null; then which ctr; else which docker-containerd-ctr; fi)
+ifeq ("$(CTR)", "$(shell which docker-containerd-ctr)")
+CONTAINERD_SOCK:=/var/run/docker/containerd/docker-containerd.sock
+else
+CONTAINERD_SOCK:=/var/run/containerd/containerd.sock
+endif
+
 all: rpm deb
 
 .PHONY: clean
 clean:
 	-$(CHOWN_TO_USER) build/
 	-$(RM) -r build/
+	-$(RM) runc.tar
+
+runc.tar:
+	sudo $(CTR) -a $(CONTAINERD_SOCK) content fetch docker.io/docker/runc:$(RUNC_REF)
+	sudo $(CTR) -a $(CONTAINERD_SOCK) image export $@ docker.io/docker/runc:$(RUNC_REF)
 
 .PHONY: rpm
-rpm:
+rpm: runc.tar
 	$(BUILD)
 	$(RUN)
 	$(CHOWN_TO_USER) build/
 
 .PHONY: deb
-deb:
+deb: runc.tar
 	$(BUILD)
 	$(RUN)
 	$(CHOWN_TO_USER) build/

--- a/common/containerd.service
+++ b/common/containerd.service
@@ -6,8 +6,9 @@ After=network.target
 [Service]
 ExecStartPre=/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd
-Delegate=yes
+ExecStartPost=/usr/libexec/containerd-offline-installer /var/lib/containerd/runc.tar docker.io/docker/runc:v1.0.0-rc5
 KillMode=process
+Delegate=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/control
+++ b/debian/control
@@ -15,8 +15,7 @@ XS-Go-Import-Path: github.com/containerd/containerd
 Package: containerd.io
 Architecture: any
 Depends: ${misc:Depends},
-         ${shlibs:Depends},
-         runc.io
+         ${shlibs:Depends}
 Provides: containerd
 Conflicts: containerd
 Replaces: containerd

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 INSTALL_DIR=debian/containerd.io
+CONTAINERD_BINARIES=bin/containerd bin/containerd-shim bin/ctr
 
 %:
 	dh $@ --with systemd
@@ -11,13 +12,19 @@ bin/%: ## Create containerd binaries
 	@echo "+ make -C $(GO_SRC_PATH) --no-print-directory VERSION=$${VERSION} REVISION=$${REF} $@"
 	@make -C $(GO_SRC_PATH) --no-print-directory VERSION=$${VERSION} REVISION=$${REF} $@
 
-override_dh_auto_build: bin/containerd bin/containerd-shim bin/ctr
+bin/containerd-offline-installer:
+	@echo "+ go build -o bin/containerd-offline-installer github.com/crosbymichael/offline-install"
+	@go build -o bin/containerd-offline-installer github.com/crosbymichael/offline-install
 
-override_dh_auto_install: bin/containerd bin/containerd-shim bin/ctr
+override_dh_auto_build: $(CONTAINERD_BINARIES)
+
+override_dh_auto_install: $(CONTAINERD_BINARIES) bin/containerd-offline-installer
 	# set -x so we can see what's being installed where
-	for binary in $^; do \
+	for binary in $(CONTAINERD_BINARIES); do \
 		dest=$$(basename $$binary); \
 		(set -x; install -D -m 0755 $(GO_SRC_PATH)/$$binary $(INSTALL_DIR)/usr/bin/$$dest); \
 	done
 	install -D -m 0644 /root/common/containerd.service $(INSTALL_DIR)/lib/systemd/system/containerd.service
 	install -D -m 0644 /root/common/containerd.toml $(INSTALL_DIR)/etc/containerd/config.toml
+	install -D -m 0644 /root/runc.tar $(INSTALL_DIR)/var/lib/containerd/runc.tar
+	install -D -m 0755 bin/containerd-offline-installer $(INSTALL_DIR)/usr/libexec/containerd-offline-installer


### PR DESCRIPTION
Installs runc on systems right after `containerd` systemd startup using @crosbymichael's [offline-install](https://github.com/crosbymichael/offline-install) utility.

Only works on versions of containerd with https://github.com/containerd/containerd/pull/2518 included.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>