### PR TITLE
Create containerd packages on multiple architectures

### DIFF
--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -1,11 +1,11 @@
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
 FROM alpine:latest as golang
-RUN apk add curl
+RUN apk -u --no-cache add curl
 ARG GO_DL_URL
 RUN curl -fsSL "${GO_DL_URL}" | tar xzC /usr/local
 
 FROM alpine:latest as containerd
-RUN apk add git
+RUN apk -u --no-cache add git
 ARG REF
 ENV IMPORT_PATH github.com/containerd/containerd
 RUN git clone https://${IMPORT_PATH}.git /containerd

--- a/scripts/build-rpm
+++ b/scripts/build-rpm
@@ -4,21 +4,22 @@ source /.rpm-helpers
 
 set -e
 
-VERSION="$(git -C "${GO_SRC_PATH}" describe --tags | sed 's/^v//')"
+git --version
+VERSION="$(git --git-dir "${GO_SRC_PATH}/.git" describe --tags | sed 's/^v//')"
 RPM_VER_BITS=$(gen-rpm-ver-bits "${VERSION}")
 RPM_VERSION=$(echo "${RPM_VER_BITS}" | cut -f1 -d' ')
 RPM_RELEASE_VERSION=$(echo "${RPM_VER_BITS}" | cut -f2 -d' ')
 
 
 # Check if we're on a tagged version, change VERSION to dev build if not
-if ! git -C "${GO_SRC_PATH}" describe --exact-match HEAD >/dev/null 2>&1; then
-    git_date=$(date --date "@$(git -C "${GO_SRC_PATH}" log -1 --pretty='%at')" +'%Y%m%d.%H%M%S')
-    git_sha=$(git -C "${GO_SRC_PATH}" log -1 --pretty='%h')
+if ! git --git-dir "${GO_SRC_PATH}/.git" describe --exact-match HEAD >/dev/null 2>&1; then
+    git_date=$(date --date "@$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%at')" +'%Y%m%d.%H%M%S')
+    git_sha=$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%h')
     VERSION="0.${git_date}~${git_sha}"
     RPM_RELEASE_VERSION=0
     RPM_VERSION="$VERSION"
 fi
-REF=$(git -C "${GO_SRC_PATH}" rev-parse HEAD)
+REF=$(git --git-dir "${GO_SRC_PATH}/.git" rev-parse HEAD)
 
 export REF
 export RPM_RELEASE_VERSION


### PR DESCRIPTION
The base images of the Dockerfiles, which we use to build the deb and rpm packages support multi- architectures.  Therefore in order to build multi architecture packages we build the packages (in a container) on multiple architectures (achieved through Jenkins nodes).

Signed-off-by: Jose Bigio <jose.bigio@docker.com>