### PR TITLE
Remove tag from offline installer

### DIFF
--- a/common/containerd.service
+++ b/common/containerd.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 ExecStartPre=/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd
-ExecStartPost=/usr/libexec/containerd-offline-installer /var/lib/containerd/runc.tar docker.io/docker/runc:v1.0.0-rc5
+ExecStartPost=/usr/libexec/containerd-offline-installer /var/lib/containerd/runc.tar docker.io/docker/runc
 KillMode=process
 Delegate=yes
 


### PR DESCRIPTION
It was appearing twice and it was annoying me

The tag is already bundled as a part of the OCI spec.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>