### PR TITLE
Package containerd on multiple distros

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,8 +38,7 @@ def genDEBBuild(String arch, String cmd) {
 				checkout scm
 				try {
 					stage("Build DEB ${arch}") {
-						sh("docker info")
-						sh("make DISTRIO=ubuntu:bionic ${cmd}")
+						sh("make ${cmd}")
 					}
 					stage("Archive DEB ${arch}") {
 						if (params.ARCHIVE) {
@@ -63,8 +62,7 @@ def genRPMBuild(String arch, String cmd) {
 				checkout scm
 				try {
 					stage("Build RPM for ${arch}") {
-						sh("docker info")
-						sh("make rpm")
+						sh("make ${cmd}")
 					}
 					stage("Archive RPM for ${arch}") {
 						if (params.ARCHIVE) {
@@ -112,14 +110,15 @@ arches = [
 ]
 
 rpms = [ 
+	"fedora-27",
 	"fedora-28",
-	"centos7"
+	"centos-7"
 ]
 
 packageLookup = [ 
+	"fedora-27": arches - ["s390x"],
 	"fedora-28": arches - ["s390x"],
-	"fedora-29": arches - ["s390x"],
-	"centos7": arches,
+	"centos-7": arches,
 	"deb" : arches
 ]
 

--- a/dockerfiles/centos.s390x.dockerfile
+++ b/dockerfiles/centos.s390x.dockerfile
@@ -1,31 +1,24 @@
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
-ARG DISTRO
-FROM ${DISTRO} as distro_image
-
 FROM alpine:latest as golang
-RUN apk add curl
+RUN apk -u --no-cache add curl
 ARG GO_DL_URL
 RUN curl -fsSL "${GO_DL_URL}" | tar xzC /usr/local
 
 FROM alpine:latest as containerd
-RUN apk add git
+RUN apk -u --no-cache add git
 ARG REF
 RUN git clone https://github.com/containerd/containerd.git /containerd
 RUN git -C /containerd checkout ${REF}
 
 FROM alpine:latest as offline-install
-RUN apk add git
+RUN apk -u --no-cache add git
 ARG OFFLINE_INSTALL_REF
 RUN git clone https://github.com/crosbymichael/offline-install.git /offline-install
 RUN git -C /offline-install checkout ${OFFLINE_INSTALL_REF}
 
-FROM distro_image
-RUN dnf -y upgrade
-RUN dnf install -y rpm-build git dnf-plugins-core
-ARG SUITE
-ENV SUITE ${SUITE}
+FROM clefos:7
+RUN yum install -y rpm-build git yum-utils gcc
 ENV GOPATH /go
-ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV GO_SRC_PATH /go/src/github.com/containerd/containerd
 COPY --from=golang /usr/local/go /usr/local/go/
 COPY --from=containerd /containerd ${GO_SRC_PATH}
@@ -36,4 +29,7 @@ COPY rpm/containerd.spec /root/rpmbuild/SPECS/containerd.spec
 COPY scripts/build-rpm /build-rpm
 COPY scripts/.rpm-helpers /.rpm-helpers
 WORKDIR /root/rpmbuild
+# Need for build-rpm on s390x
+RUN ln /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENTRYPOINT ["/build-rpm"]

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -1,7 +1,4 @@
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
-ARG DISTRO
-FROM ${DISTRO} as distro
-
 FROM alpine:latest as golang
 RUN apk -u --no-cache add curl
 ARG GO_DL_URL
@@ -20,8 +17,7 @@ ARG OFFLINE_INSTALL_REF
 RUN git clone https://github.com/crosbymichael/offline-install.git /offline-install
 RUN git -C /offline-install checkout ${OFFLINE_INSTALL_REF}
 
-#FROM ubuntu:bionic
-FROM distro
+FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPATH /go
 ENV GO_SRC_PATH /go/src/github.com/containerd/containerd

--- a/dockerfiles/fedora-27.dockerfile
+++ b/dockerfiles/fedora-27.dockerfile
@@ -1,23 +1,26 @@
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
+
 FROM alpine:latest as golang
-RUN apk -u --no-cache add curl
+RUN apk add curl
 ARG GO_DL_URL
 RUN curl -fsSL "${GO_DL_URL}" | tar xzC /usr/local
 
 FROM alpine:latest as containerd
-RUN apk -u --no-cache add git
+RUN apk add git
 ARG REF
 RUN git clone https://github.com/containerd/containerd.git /containerd
 RUN git -C /containerd checkout ${REF}
 
 FROM alpine:latest as offline-install
-RUN apk -u --no-cache add git
+RUN apk add git
 ARG OFFLINE_INSTALL_REF
 RUN git clone https://github.com/crosbymichael/offline-install.git /offline-install
 RUN git -C /offline-install checkout ${OFFLINE_INSTALL_REF}
 
-FROM centos:7
-RUN yum install -y rpm-build git
+FROM fedora:27
+RUN dnf -y upgrade
+RUN dnf install -y rpm-build git dnf-plugins-core
+ENV SUITE 27
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV GO_SRC_PATH /go/src/github.com/containerd/containerd
@@ -30,6 +33,4 @@ COPY rpm/containerd.spec /root/rpmbuild/SPECS/containerd.spec
 COPY scripts/build-rpm /build-rpm
 COPY scripts/.rpm-helpers /.rpm-helpers
 WORKDIR /root/rpmbuild
-# Overwrite repo that was failing on aarch64
-RUN sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo
 ENTRYPOINT ["/build-rpm"]

--- a/dockerfiles/fedora-28.dockerfile
+++ b/dockerfiles/fedora-28.dockerfile
@@ -1,23 +1,25 @@
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
 FROM alpine:latest as golang
-RUN apk -u --no-cache add curl
+RUN apk add curl
 ARG GO_DL_URL
 RUN curl -fsSL "${GO_DL_URL}" | tar xzC /usr/local
 
 FROM alpine:latest as containerd
-RUN apk -u --no-cache add git
+RUN apk add git
 ARG REF
 RUN git clone https://github.com/containerd/containerd.git /containerd
 RUN git -C /containerd checkout ${REF}
 
 FROM alpine:latest as offline-install
-RUN apk -u --no-cache add git
+RUN apk add git
 ARG OFFLINE_INSTALL_REF
 RUN git clone https://github.com/crosbymichael/offline-install.git /offline-install
 RUN git -C /offline-install checkout ${OFFLINE_INSTALL_REF}
 
-FROM centos:7
-RUN yum install -y rpm-build git
+FROM fedora:28
+RUN dnf -y upgrade
+RUN dnf install -y rpm-build git dnf-plugins-core
+ENV SUITE 28
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV GO_SRC_PATH /go/src/github.com/containerd/containerd
@@ -30,6 +32,4 @@ COPY rpm/containerd.spec /root/rpmbuild/SPECS/containerd.spec
 COPY scripts/build-rpm /build-rpm
 COPY scripts/.rpm-helpers /.rpm-helpers
 WORKDIR /root/rpmbuild
-# Overwrite repo that was failing on aarch64
-RUN sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo
 ENTRYPOINT ["/build-rpm"]

--- a/scripts/build-rpm
+++ b/scripts/build-rpm
@@ -39,8 +39,9 @@ export RPM_VERSION
 export VERSION
 
 DIST=$( get_distribution)
-if [[ $DIST  == centos ]]; then
+if [ $DIST  == centos ] || [ $DIST == clefos ]; then
     (set -x; yum-builddep -y SPECS/containerd.spec; rpmbuild -ba SPECS/containerd.spec)
 else
+    echo Distribution is $DIST
     (set -x; dnf builddep -y SPECS/containerd.spec; rpmbuild -ba SPECS/containerd.spec)
 fi


### PR DESCRIPTION
Builds containerd packaging on multiple distributions. 
For deb based packages we only need to build one package which can be used on all other distributions. (Same package for different versions of Ubuntu and Debian). 

For RPM packages need to build on fedora and centos.
Note we do not build s390x images on Fedora. 

Thanks to @corbin-coleman for helping me correctly set up the path and linking for `s390x-linux-gnu-gcc`.

### Note 

Ideally we should be able to eliminate the need to have multiple fedora dockerfiles, and probably also the need to have separate centos dockerfiles.  I had this working on this branch https://github.com/jose-bigio/containerd-packaging/tree/multi_distros_build_args (needs extra changes for s390x) but I abandoned getting this to work because I was seeing failure in Jenkins. 
This is a future improvement we can make.