### PR TITLE
Bump to v1.2.0-beta.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-containerd.io (1.1.0-1) UNRELEASED; urgency=medium
+containerd.io (1.2.0~beta.0-1) release; urgency=medium
 
-  * Initial release (Closes: TODO)
+  * Initial release
 
- -- Eli Uriegas <eli.uriegas@docker.com>  Mon, 23 Apr 2018 21:08:40 +0000
+ -- Eli Uriegas <eli.uriegas@docker.com>  Thu, 16 Aug 2018 16:54:35 +0000

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -127,5 +127,5 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
-* Tue May 01 2018 Jose Bigio <jose.bigio@docker.com> - 1.1.0
-- Initial Package
+* Thu Aug 16 2018 Eli Uriegas <eli.uriegas@docker.com> - 1.2.0-1.0.beta.0-1
+- Intial release


### PR DESCRIPTION
https://github.com/containerd/containerd/releases/tag/v1.2.0-beta.0

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>