### PR TITLE
Use a build arg to determine base builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ RUNC_REF?=v1.0.0-rc5
 OFFLINE_INSTALL_REF?=8c1658b29376a51eb1ae0f311706331fcea69b18
 GOVERSION?=1.10.3
 GOLANG_IMAGE?=golang:1.10.3
+BUILD_IMAGE?=
 
 # need specific repos for s390x
 ifeq ($(ARCH),s390x)
@@ -16,6 +17,7 @@ endif
 
 BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD)
 BUILD=docker build \
+	 --build-arg BUILD_IMAGE="$(BUILD_IMAGE)" \
 	 --build-arg GOLANG_IMAGE="$(GOLANG_IMAGE)" \
 	 --build-arg REF="$(REF)" \
 	 --build-arg OFFLINE_INSTALL_REF="$(OFFLINE_INSTALL_REF)" \

--- a/dockerfiles/centos.dockerfile
+++ b/dockerfiles/centos.dockerfile
@@ -1,3 +1,4 @@
+ARG BUILD_IMAGE=centos:7
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
 ARG GOLANG_IMAGE
 FROM ${GOLANG_IMAGE} as golang
@@ -14,7 +15,7 @@ ARG OFFLINE_INSTALL_REF
 RUN git clone https://github.com/crosbymichael/offline-install.git /offline-install
 RUN git -C /offline-install checkout ${OFFLINE_INSTALL_REF}
 
-FROM centos:7
+FROM ${BUILD_IMAGE}
 RUN yum install -y rpm-build git
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -1,3 +1,4 @@
+ARG BUILD_IMAGE=ubuntu:bionic
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
 ARG GOLANG_IMAGE
 FROM ${GOLANG_IMAGE} as golang
@@ -15,7 +16,7 @@ ARG OFFLINE_INSTALL_REF
 RUN git clone https://github.com/crosbymichael/offline-install.git /offline-install
 RUN git -C /offline-install checkout ${OFFLINE_INSTALL_REF}
 
-FROM ubuntu:bionic
+FROM ${BUILD_IMAGE}
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPATH /go
 ENV GO_SRC_PATH /go/src/github.com/containerd/containerd

--- a/dockerfiles/sles.dockerfile
+++ b/dockerfiles/sles.dockerfile
@@ -1,3 +1,4 @@
+ARG BUILD_IMAGE=dockereng/sles:12.2
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
 ARG GOLANG_IMAGE
 FROM ${GOLANG_IMAGE} as golang
@@ -14,7 +15,7 @@ ARG OFFLINE_INSTALL_REF
 RUN git clone https://github.com/crosbymichael/offline-install.git /offline-install
 RUN git -C /offline-install checkout ${OFFLINE_INSTALL_REF}
 
-FROM dockereng/sles:12.2
+FROM ${BUILD_IMAGE}
 RUN zypper install -y rpm-build git
 RUN zypper install -y \
     make \


### PR DESCRIPTION
You can use a build arg to determine the base builder image if the ARG is defined first at the top of the Dockerfile.
This will allow us to use only 1 dockerfile even for our images that needed to be compiled with go-crypto-swap for FIPS compliance.

Signed-off-by: corbin-coleman <corbin.coleman@docker.com>