### PR TITLE
Increment containerd version for deb, add changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.2.0~beta.2-2) release; urgency=medium
+
+  * Removed offline installer for runc, package as a binary instead
+
+ -- Eli Uriegas <eli.uriegas@docker.com>  Fri, 14 Sep 2018 09:22:21 -0700
+
 containerd.io (1.2.0~beta.2-1) release; urgency=medium
 
   * containerd 1.2.0 beta.2 release

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -135,6 +135,7 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 %changelog
 * Wed Sep 05 2018 Eli Uriegas <eli.uriegas@docker.com> - 1.2.0-1.2.beta.2.2
 - Hardcoded paths for libexec and var lib considering the macros are different on SUSE based distributions
+- Removed offline installer for runc, package as a binary instead
 
 * Tue Aug 28 2018 Andrew Hsu <andrewhsu@docker.com> - 1.2.0-1.2.beta.2.1
 - containerd 1.2.0 beta.2


### PR DESCRIPTION
Increments DEB versioning to release version 2 so we can release new packages for both deb and rpm

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>