### PR TITLE
Compile runc with 'seccomp apparmor selinux'

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ bin/%: ## Create containerd binaries
 	mv -v $(GO_SRC_PATH)/$@ $@
 
 bin/runc:
-	make -C /go/src/github.com/opencontainers/runc runc && mv -v /go/src/github.com/opencontainers/runc/runc $@
+	make -C /go/src/github.com/opencontainers/runc BUILDTAGS='seccomp apparmor selinux' runc && mv -v /go/src/github.com/opencontainers/runc/runc $@
 
 override_dh_auto_build: $(CONTAINERD_BINARIES)
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -87,7 +87,7 @@ pushd /go/src/%{import_path}
 popd
 
 pushd /go/src/github.com/opencontainers/runc
-make runc
+make BUILDTAGS='seccomp apparmor selinux' runc
 popd
 
 


### PR DESCRIPTION
Containers were not running with the message:

```
docker@eli-work-testkit-2005FF-ubuntu-0:~$ docker run --rm -it hello-world
docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "process_linux.go:402: container init caused \"apparmor: config provided but apparmor not supported\"": unknown.
```

Reference: https://github.com/moby/moby/blob/a9c061deec0f8d452e4feb7258046d5e32a1143b/hack/dockerfile/install/runc.installer#L6-L22

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>