### PR TITLE
containerd.service: set TasksMax=infinity

### DIFF
--- a/common/containerd.service
+++ b/common/containerd.service
@@ -13,6 +13,7 @@ LimitNOFILE=1048576
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
+TasksMax=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Some systems, notably SLES 12sp3, have TasksMax=512 by default,
which gravely limits the ability of containerd to function.

Set TasksMax=infinity as we do for dockerd.

For info about which systemd/distro relases supports/needs this, see
https://github.com/docker/docker-ee/pull/164#issuecomment-358509866

TL;DR:

* the setting is needed by SLES, Debian 8+, Ubuntu 16.04+, Fedora 25+,
and is not required (but supported so silently ignored) for RHEL7.

* the setting can cause a warning for Debian 8 (which comes with
systemd 215 which doesn't have TasksMax, but backports include systemd
230 that does).

Based on that, we just enable it unconditionally.

Should fix https://github.com/docker/docker-core-backlog/issues/452 and possibly other SLES issues.