### PR TITLE
Ignore result of modprobe overlay

### DIFF
--- a/common/containerd.service
+++ b/common/containerd.service
@@ -4,7 +4,7 @@ Documentation=https://containerd.io
 After=network.target
 
 [Service]
-ExecStartPre=/sbin/modprobe overlay
+ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd
 KillMode=process
 Delegate=yes


### PR DESCRIPTION
Was causing issues on systems that do not have the overlay module
installed.

Closes https://github.com/docker/docker-core-backlog/issues/500

Related issues 
* https://github.com/docker/for-linux/issues/475 
* https://github.com/moby/moby/issues/3815
* https://github.com/containerd/containerd/issues/2772


Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>