### PR TITLE
Mark package as "providing", "conflicting" and "obsoletes" runc

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Package: containerd.io
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends}
-Provides: containerd
-Conflicts: containerd
-Replaces: containerd
+Provides: containerd, runc
+Conflicts: containerd, runc
+Replaces: containerd, runc
 Description: An open and reliable container runtime

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -29,8 +29,16 @@ AutoReq: no
 
 Name: containerd.io
 Provides: containerd
+Provides: runc
+
+# Obsolete packages
 Obsoletes: containerd
+Obsoletes: runc
+
+# Conflicting packages
 Conflicts: containerd
+Conflicts: runc
+
 Version: %{getenv:RPM_VERSION}
 Release: %{getenv:RPM_RELEASE_VERSION}%{?dist}
 Summary: An industry-standard container runtime


### PR DESCRIPTION
Addresses https://github.com/moby/moby/issues/38185

Some distros ship containerd and runc as separate packages, and because of this, installation of this package fails if the distro-provided runc package is installed:

    The following additional packages will be installed:
      containerd.io
    The following NEW packages will be installed
      containerd.io
    0 to upgrade, 1 to newly install, 0 to remove and 1 not to upgrade.
    1 not fully installed or removed.
    Need to get 0 B/19.9 MB of archives.
    After this operation, 87.6 MB of additional disk space will be used.
    Do you want to continue? [Y/n] Y
    (Reading database ... 523620 files and directories currently installed.)
    Preparing to unpack .../containerd.io_1.2.0-1_amd64.deb ...
    Unpacking containerd.io (1.2.0-1) ...
    dpkg: error processing archive /var/cache/apt/archives/containerd.io_1.2.0-1_amd64.deb (--unpack):
     trying to overwrite '/usr/sbin/runc', which is also in package runc 1.0.0~rc2+docker1.13.1-0ubuntu1~16.04.1
    dpkg-deb: error: subprocess paste was killed by signal (Broken pipe)
    Errors were encountered while processing:
     /var/cache/apt/archives/containerd.io_1.2.0-1_amd64.deb
    E: Sub-process /usr/bin/dpkg returned an error code (1)

This patch indicates that this package;

- provides runc
- conflicts with other runc packages
- obsoletes existing runc packages

We should verify if this will cause issues in future, once runc becomes stable (reaches 1.0), at which point we may want to allow depending on the distro packages and/or put runc in its own package.