### PR TITLE
Bump Go to 1.10.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,17 +126,17 @@ packageLookup = [
 ]
 
 golangRPMImages = [
-	"fedora-27": "golang:1.10.3",
-	"fedora-28": "golang:1.10.3",
-	"centos-7": "dockereng/go-crypto-swap:centos-go1.10.4-92409f5",
-	"sles": "dockereng/go-crypto-swap:sles-go1.10.4-92409f5",
+	"fedora-27": "golang:1.10.5",
+	"fedora-28": "golang:1.10.5",
+	"centos-7": "dockereng/go-crypto-swap:centos-go1.10.5-cd940a7",
+	"sles": "dockereng/go-crypto-swap:sles-go1.10.5-cd940a7",
 ]
 
 buildSteps = [:]
 for (rpm in rpms) {
 	arches = packageLookup[rpm]
 	for (arch in arches) {
-		golangImage = "golang:1.10.3"
+		golangImage = "golang:1.10.5"
 		buildImage = rpm.replaceAll('-', ':')
 		if (rpm == 'sles') {
 			buildImage = "dockereng/sles:12.2"
@@ -153,10 +153,10 @@ for (rpm in rpms) {
 
 arches = packageLookup["deb"]
 for (arch in arches) {
-	golangImage = "golang:1.10.3"
+	golangImage = "golang:1.10.5"
 	buildImage = "ubuntu:bionic"
 	if (arch == "x86_64") {
-		golangImage = "dockereng/go-crypto-swap:bionic-go1.10.4-92409f5"
+		golangImage = "dockereng/go-crypto-swap:bionic-go1.10.5-cd940a7"
 		buildImage = golangImage
 	}
 	buildSteps << genDEBBuild(arch, "deb", golangImage, buildImage)

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 ARCH:=$(shell uname -m)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=10d38b660a77168360df3522881e2dc2be5056bd
-GOVERSION?=1.10.3
-GOLANG_IMAGE?=golang:1.10.3
+GOVERSION?=1.10.5
+GOLANG_IMAGE?=golang:1.10.5
 
 # need specific repos for s390x
 ifeq ($(ARCH),s390x)

--- a/dockerfiles/windows.dockerfile
+++ b/dockerfiles/windows.dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM dockereng/go-crypto-swap:windows-go1.10.3-92409f5
+FROM dockereng/go-crypto-swap:windows-go1.10.5-cd940a7
 ENV AUTO_GOPATH=1
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 RUN Invoke-WebRequest 'https://raw.githubusercontent.com/jhowardmsft/docker-tdmgcc/master/gcc.zip' -OutFile C:\gcc.zip; `

--- a/scripts/gen-go-dl-url
+++ b/scripts/gen-go-dl-url
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GOVERSION=${GOVERSION:-1.10.3}
+GOVERSION=${GOVERSION:-1.10.5}
 HOST_ARCH=${HOST_ARCH:-$(uname -m)}
 DL_ARCH=${HOST_ARCH}
 


### PR DESCRIPTION
~Looks like we don't have images yet to build for 1.10.5, so I used the last version that's available on Docker Hub; https://hub.docker.com/r/dockereng/go-crypto-swap/tags/~

images are built; updated