### PR TITLE
bump ver for containerd 1.2.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 ARCH:=$(shell uname -m)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
-RUNC_REF?=10d38b660a77168360df3522881e2dc2be5056bd
+RUNC_REF?=96ec2177ae841256168fcf76954f7177af9446eb
 GOVERSION?=1.10.5
 GOLANG_IMAGE?=golang:1.10.5
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 containerd.io (1.2.1-1) release; urgency=medium
 
   * containerd 1.2.1 release
+  * update runc to 96ec2177ae841256168fcf76954f7177af9446eb
 
  -- Andrew Hsu <andrewhsu@docker.com>  Thu, 06 Dec 2018 00:50:40 +0000
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -143,6 +143,7 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 %changelog
 * Thu Dec 06 2018 Andrew Hsu <andrewhsu@docker.com> - 1.2.1-3.1
 - containerd 1.2.1 release
+- update runc to 96ec2177ae841256168fcf76954f7177af9446eb
 
 * Tue Nov 27 2018  Sebastiaan van Stijn <thajeztah@docker.com> - v1.2.1-2.0.rc.0.1
 - containerd 1.2.1-rc.0 release


### PR DESCRIPTION
i updated the packaging versions:
```
./scripts/new-deb-release 1.2.1
./scripts/new-rpm-release 1.2.1
```

and i updated runc to the hash specified in containerd's `vendor.conf`