### PR TITLE
Remove go-md2man as a BuildRequires, prefer go get

### DIFF
--- a/dockerfiles/centos.dockerfile
+++ b/dockerfiles/centos.dockerfile
@@ -21,6 +21,7 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV GO_SRC_PATH /go/src/github.com/containerd/containerd
 COPY --from=golang /usr/local/go /usr/local/go/
+RUN go get github.com/cpuguy83/go-md2man
 COPY --from=containerd /containerd ${GO_SRC_PATH}
 COPY --from=runc /runc /go/src/github.com/opencontainers/runc
 COPY common/ /root/rpmbuild/SOURCES/

--- a/dockerfiles/centos.s390x.dockerfile
+++ b/dockerfiles/centos.s390x.dockerfile
@@ -19,6 +19,7 @@ RUN yum install -y rpm-build git yum-utils gcc
 ENV GOPATH /go
 ENV GO_SRC_PATH /go/src/github.com/containerd/containerd
 COPY --from=golang /usr/local/go /usr/local/go/
+RUN go get github.com/cpuguy83/go-md2man
 COPY --from=containerd /containerd ${GO_SRC_PATH}
 COPY --from=runc /runc /go/src/github.com/opencontainers/runc
 COPY common/ /root/rpmbuild/SOURCES/

--- a/dockerfiles/fedora.dockerfile
+++ b/dockerfiles/fedora.dockerfile
@@ -24,6 +24,7 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV GO_SRC_PATH /go/src/github.com/containerd/containerd
 COPY --from=golang /usr/local/go /usr/local/go/
+RUN go get github.com/cpuguy83/go-md2man
 COPY --from=containerd /containerd ${GO_SRC_PATH}
 COPY --from=runc /runc /go/src/github.com/opencontainers/runc
 COPY common/ /root/rpmbuild/SOURCES/

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -58,7 +58,6 @@ BuildRequires: libseccomp-devel
 BuildRequires: libbtrfs-devel
 %else
 BuildRequires: btrfs-progs-devel
-BuildRequires: go-md2man
 %endif
 
 %{?systemd_requires}


### PR DESCRIPTION
go-md2man mysteriously disappeared from the centos 7 package
repositories, let's just install it using go just to be safe.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>