### PR TITLE
Bump to package version 1.2.2-2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.2.2-2) release; urgency=medium
+
+  * update runc to f7491ef134a6c41f3a99b0b539835d2472d17012
+
+ -- Eli Uriegas <eli.uriegas@docker.com>  Fri, 18 Jan 2019 00:12:35 +0000
+
 containerd.io (1.2.2-1) release; urgency=medium
 
   * containerd 1.2.2 release

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -141,6 +141,9 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Fri Jan 18 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.2-3.2
+- update runc to f7491ef134a6c41f3a99b0b539835d2472d17012
+
 * Tue Jan 08 2019 Andrew Hsu <andrewhsu@docker.com> - 1.2.2-3.1
 - containerd 1.2.2 release
 


### PR DESCRIPTION
Includes bump for runc to newer version, relies on https://github.com/docker/release-packaging/pull/302

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>