### PR TITLE
Add in versioning dot for package only updates

### DIFF
--- a/scripts/.rpm-helpers
+++ b/scripts/.rpm-helpers
@@ -19,15 +19,25 @@ gen-test-ver() {
 
 gen-rpm-ver-bits() {
     VERSION=$1
+    VER_DOT=$(gen-rpm-release-ver-dot "${VERSION}")
     case "$VERSION" in
         *beta*)
-            result="${VERSION%-beta.*} $(gen-test-ver "${VERSION}" beta 1)"
+            result="${VERSION%-beta.*} $(gen-test-ver "${VERSION}" beta 1)${VER_DOT}"
             ;;
         *rc*)
-            result="${VERSION%-rc.*} $(gen-test-ver "${VERSION}" rc 2)"
+            result="${VERSION%-rc.*} $(gen-test-ver "${VERSION}" rc 2)${VER_DOT}"
             ;;
         *)
-            result="${VERSION} 3"
+            result="${VERSION} 3${VER_DOT}"
     esac
     echo "$result"
+}
+
+gen-rpm-release-ver-dot() {
+    VERSION=$1
+    SPEC_FILE=${SPEC_FILE:-SPECS/containerd.spec}
+    # Find if the version is just releasing a package version
+    if grep -q "${VERSION}-" "${SPEC_FILE}"; then
+        echo ".$(grep -c "${VERSION}-" "${SPEC_FILE}")"
+    fi
 }


### PR DESCRIPTION
New rpm version strings should look somewhat similar to

> build/centos-7/RPMS/x86_64/containerd.io-1.2.2-3.2.el7.x86_64.rpm

Note the 3.2 after the 1.2.2 versioning

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>