### PR TITLE
Bump package version to 1.2.2-3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.2.2-3) release; urgency=high
+
+  * [runc -> 09c8266] nsenter: clone /proc/self/exe to avoid exposing
+    host binary to container (CVE-2019-5736)
+
+ -- Eli Uriegas <eli.uriegas@docker.com>  Thu, 31 Jan 2019 22:30:30 +0000
+
 containerd.io (1.2.2-2) release; urgency=medium
 
   * update runc to f7491ef134a6c41f3a99b0b539835d2472d17012

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -141,6 +141,10 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Thu Jan 31 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.2-3.3
+- [runc -> 09c8266] nsenter: clone /proc/self/exe to avoid exposing
+  host binary to container (CVE-2019-5736)
+
 * Fri Jan 18 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.2-3.2
 - update runc to f7491ef134a6c41f3a99b0b539835d2472d17012
 


### PR DESCRIPTION
Includes the fix found in https://github.com/docker/fork-knox-runc/pull/7

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>