### PR TITLE
Bump Golang 1.10.8 (CVE-2019-6486)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,17 +126,17 @@ packageLookup = [
 ]
 
 golangRPMImages = [
-	"fedora-27": "golang:1.10.6",
-	"fedora-28": "golang:1.10.6",
-	"centos-7": "dockereng/go-crypto-swap:centos-7-go1.10.6",
-	"sles": "dockereng/go-crypto-swap:sles-12.3-go1.10.6",
+	"fedora-27": "golang:1.10.8",
+	"fedora-28": "golang:1.10.8",
+	"centos-7": "dockereng/go-crypto-swap:centos-7-go1.10.8",
+	"sles": "dockereng/go-crypto-swap:sles-12.3-go1.10.8",
 ]
 
 buildSteps = [:]
 for (rpm in rpms) {
 	arches = packageLookup[rpm]
 	for (arch in arches) {
-		golangImage = "golang:1.10.6"
+		golangImage = "golang:1.10.8"
 		buildImage = rpm.replaceAll('-', ':')
 		if (rpm == 'sles') {
 			buildImage = "dockereng/sles:12.3"
@@ -153,10 +153,10 @@ for (rpm in rpms) {
 
 arches = packageLookup["deb"]
 for (arch in arches) {
-	golangImage = "golang:1.10.6"
+	golangImage = "golang:1.10.8"
 	buildImage = "ubuntu:bionic"
 	if (arch == "x86_64") {
-		golangImage = "dockereng/go-crypto-swap:bionic-go1.10.6-7c3f30e"
+		golangImage = "dockereng/go-crypto-swap:ubuntu-18.04-go1.10.8"
 		buildImage = golangImage
 	}
 	buildSteps << genDEBBuild(arch, "deb", golangImage, buildImage)

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 ARCH:=$(shell uname -m)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=96ec2177ae841256168fcf76954f7177af9446eb
-GOVERSION?=1.10.6
-GOLANG_IMAGE?=golang:1.10.6
+GOVERSION?=1.10.8
+GOLANG_IMAGE?=golang:1.10.8
 
 # need specific repos for s390x
 ifeq ($(ARCH),s390x)
@@ -42,7 +42,7 @@ CONTAINERD_BRANCH?=release/1.2
 CONTAINERD_DIR?=$(shell basename $(CONTAINERD_REPO))
 CONTAINERD_MOUNT?=C:\gopath\src\github.com\containerd\containerd
 WINDOWS_BINARIES=containerd ctr
-WIN_CRYPTO=dockereng/go-crypto-swap:windows-go1.10.6-7c3f30e
+WIN_CRYPTO=dockereng/go-crypto-swap:windows-go1.10.8
 
 # Build tags seccomp and apparmor are needed by CRI plugin.
 BUILDTAGS ?= seccomp apparmor

--- a/scripts/gen-go-dl-url
+++ b/scripts/gen-go-dl-url
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GOVERSION=${GOVERSION:-1.10.6}
+GOVERSION=${GOVERSION:-1.10.8}
 HOST_ARCH=${HOST_ARCH:-$(uname -m)}
 DL_ARCH=${HOST_ARCH}
 


### PR DESCRIPTION
See the milestone for details;
https://github.com/golang/go/issues?q=milestone%3AGo1.10.8+label%3ACherryPickApproved
