### PR TITLE
Fix go-md2man dependency

### DIFF
--- a/dockerfiles/centos.dockerfile
+++ b/dockerfiles/centos.dockerfile
@@ -15,7 +15,8 @@ RUN git clone https://github.com/crosbymichael/offline-install.git /offline-inst
 RUN git -C /offline-install checkout ${OFFLINE_INSTALL_REF}
 
 FROM centos:7
-RUN yum install -y rpm-build git
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y rpm-build git 
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV GO_SRC_PATH /go/src/github.com/containerd/containerd

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -49,7 +49,7 @@ BuildRequires: libseccomp-devel
 BuildRequires: libbtrfs-devel
 %else
 BuildRequires: btrfs-progs-devel
-BuildRequires: go-md2man
+BuildRequires: golang-github-cpuguy83-go-md2man
 %endif
 
 %{?systemd_requires}


### PR DESCRIPTION
make rpm was failing as go-md2an is no longer available in the CentOS or
Fedora repositories. It's now in EPEL and the package name has changed
to golang-github-cpuguy83-go-md2man. This requires enabling EPEL for
Centos

Signed-off-by: Dave Tucker <dt@docker.com>