### PR TITLE
[TAR-514] RHEL 8 Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ deb:
 	$(CHOWN_TO_USER) build/
 
 .PHONY: rpm
-rpm:  centos-7 fedora-28
+rpm:  centos-7 fedora-28 rhel-8
 
 .PHONY: centos-7
 centos-7:
@@ -78,6 +78,15 @@ centos-7:
 	-f dockerfiles/$(DOCKER_FILE_PREFIX).dockerfile \
 	-t $(BUILDER_IMAGE) .
 	docker run --rm $(VOLUME_MOUNTS) --env RUNC_NOKMEM=nokmem -t $(BUILDER_IMAGE)
+	$(CHOWN_TO_USER) build/
+
+.PHONY: rhel-8
+rhel-8:
+	# TODO: Add btrfs back if it's packaged in RHEL 8 GA
+	$(BUILD) \
+	-f dockerfiles/rhel.dockerfile \
+	-t $(BUILDER_IMAGE) .
+	docker run --rm $(VOLUME_MOUNTS) -t $(BUILDER_IMAGE)
 	$(CHOWN_TO_USER) build/
 
 .PHONY: fedora-%

--- a/dockerfiles/rhel.dockerfile
+++ b/dockerfiles/rhel.dockerfile
@@ -1,0 +1,33 @@
+ARG BUILD_IMAGE=dockereng/rhel-8:latest
+# Install golang since the package managed one probably is too old and ppa's don't cover all distros
+ARG GOLANG_IMAGE
+FROM ${GOLANG_IMAGE} as golang
+
+FROM alpine:3.8 as containerd
+RUN apk -u --no-cache add git
+ARG REF
+RUN git clone https://github.com/containerd/containerd.git /containerd
+RUN git -C /containerd checkout ${REF}
+
+FROM alpine:3.8 as runc
+RUN apk -u --no-cache add git
+ARG RUNC_REF
+RUN git clone https://github.com/opencontainers/runc.git /runc
+RUN git -C /runc checkout ${RUNC_REF}
+
+FROM ${BUILD_IMAGE}
+RUN yum install -y rpm-build yum-utils git
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV GO_SRC_PATH /go/src/github.com/containerd/containerd
+ENV BUILDTAGS no_btrfs
+COPY --from=golang /usr/local/go /usr/local/go/
+RUN go get github.com/cpuguy83/go-md2man
+COPY --from=containerd /containerd ${GO_SRC_PATH}
+COPY --from=runc /runc /go/src/github.com/opencontainers/runc
+COPY common/ /root/rpmbuild/SOURCES/
+COPY rpm/containerd.spec /root/rpmbuild/SPECS/containerd.spec
+COPY scripts/build-rpm /build-rpm
+COPY scripts/.rpm-helpers /.rpm-helpers
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/build-rpm"]

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -54,10 +54,13 @@ BuildRequires: gcc
 BuildRequires: systemd
 BuildRequires: libseccomp-devel
 
+# Should only return true if `el8` (rhel8) is NOT defined
+%if 0%{!?el8:1}
 %if 0%{?suse_version}
 BuildRequires: libbtrfs-devel
 %else
 BuildRequires: btrfs-progs-devel
+%endif
 %endif
 
 %{?systemd_requires}

--- a/scripts/build-rpm
+++ b/scripts/build-rpm
@@ -41,7 +41,7 @@ export VERSION
 DIST=$( get_distribution)
 if [ "$DIST"  == centos ] || [ "$DIST" == clefos ]; then
     (set -x; yum-builddep -y SPECS/containerd.spec; rpmbuild -ba SPECS/containerd.spec)
-elif [ "$DIST" == fedora ]; then
+elif [ "$DIST" == fedora ] || [ "$DIST" == rhel ]; then
     (set -x; dnf builddep -y SPECS/containerd.spec; rpmbuild -ba SPECS/containerd.spec)
 else
     # For distributions who don't have a builddep step, not naming names...


### PR DESCRIPTION
This commit adds the necessary Makefile/Dockerfile changes to support
packaging on RHEL 8. Notably BTRFS is disabled for containerd builds on
this OS as the btrfs-progs package is not available during the beta. It
may also not be available at GA.

Signed-off-by: Dave Tucker <dt@docker.com>