### PR TITLE
Set packagename to containerd.io in version, and make it configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 ARCH:=$(shell uname -m)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=029124da7af7360afa781a0234d1b083550f797c
+PACKAGE?=containerd.io
 GOVERSION?=1.11.8
 GOLANG_IMAGE?=golang:1.11.8
 
@@ -21,6 +22,7 @@ BUILD=docker build \
 	$(BUILD_IMAGE_FLAG) \
 	--build-arg GOLANG_IMAGE="$(GOLANG_IMAGE)" \
 	--build-arg REF="$(REF)" \
+	--build-arg PACKAGE="$(PACKAGE)" \
 	--build-arg RUNC_REF="$(RUNC_REF)"
 
 VOLUME_MOUNTS=-v "$(CURDIR)/build/DEB:/out" \
@@ -47,7 +49,7 @@ WIN_CRYPTO=dockereng/go-crypto-swap:windows-go1.11.8
 # Build tags seccomp and apparmor are needed by CRI plugin.
 BUILDTAGS ?= seccomp apparmor
 GO_TAGS=$(if $(BUILDTAGS),-tags "$(BUILDTAGS)",)
-GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) $(EXTRA_LDFLAGS)'
+GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)'
 
 all: rpm deb
 

--- a/debian/rules
+++ b/debian/rules
@@ -6,11 +6,11 @@ CONTAINERD_BINARIES=bin/containerd bin/containerd-shim bin/ctr
 %:
 	dh $@ --with systemd
 
-# GO_SRC_PATH are defined in the dockerfile
+# GO_SRC_PATH and PACKAGE are defined in the dockerfile
 # VERSION and REF are defined in scripts/build-deb
 bin/%: ## Create containerd binaries
-	@echo "+ make -C $(GO_SRC_PATH) --no-print-directory VERSION=$${VERSION} REVISION=$${REF} $@"
-	@make -C $(GO_SRC_PATH) --no-print-directory VERSION=$${VERSION} REVISION=$${REF} $@
+	@echo "+ make -C $(GO_SRC_PATH) --no-print-directory VERSION=$${VERSION} REVISION=$${REF} PACKAGE=$${PACKAGE} $@"
+	@make -C $(GO_SRC_PATH) --no-print-directory VERSION=$${VERSION} REVISION=$${REF} PACKAGE=$${PACKAGE} $@
 	mkdir -p $(@D)
 	mv -v $(GO_SRC_PATH)/$@ $@
 

--- a/dockerfiles/centos.dockerfile
+++ b/dockerfiles/centos.dockerfile
@@ -31,4 +31,7 @@ COPY scripts/.rpm-helpers /.rpm-helpers
 WORKDIR /root/rpmbuild
 # Overwrite repo that was failing on aarch64
 RUN sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo
+
+ARG PACKAGE
+ENV PACKAGE=${PACKAGE:-containerd.io}
 ENTRYPOINT ["/build-rpm"]

--- a/dockerfiles/centos.s390x.dockerfile
+++ b/dockerfiles/centos.s390x.dockerfile
@@ -30,4 +30,7 @@ WORKDIR /root/rpmbuild
 # Need for build-rpm on s390x
 RUN ln /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+
+ARG PACKAGE
+ENV PACKAGE=${PACKAGE:-containerd.io}
 ENTRYPOINT ["/build-rpm"]

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -39,4 +39,6 @@ RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-reco
 COPY scripts/build-deb /build-deb
 COPY scripts/.helpers /.helpers
 
+ARG PACKAGE
+ENV PACKAGE=${PACKAGE:-containerd.io}
 ENTRYPOINT ["/build-deb"]

--- a/dockerfiles/fedora.dockerfile
+++ b/dockerfiles/fedora.dockerfile
@@ -32,4 +32,7 @@ COPY rpm/containerd.spec /root/rpmbuild/SPECS/containerd.spec
 COPY scripts/build-rpm /build-rpm
 COPY scripts/.rpm-helpers /.rpm-helpers
 WORKDIR /root/rpmbuild
+
+ARG PACKAGE
+ENV PACKAGE=${PACKAGE:-containerd.io}
 ENTRYPOINT ["/build-rpm"]

--- a/dockerfiles/rhel.dockerfile
+++ b/dockerfiles/rhel.dockerfile
@@ -30,4 +30,7 @@ COPY rpm/containerd.spec /root/rpmbuild/SPECS/containerd.spec
 COPY scripts/build-rpm /build-rpm
 COPY scripts/.rpm-helpers /.rpm-helpers
 WORKDIR /root/rpmbuild
+
+ARG PACKAGE
+ENV PACKAGE=${PACKAGE:-containerd.io}
 ENTRYPOINT ["/build-rpm"]

--- a/dockerfiles/sles.dockerfile
+++ b/dockerfiles/sles.dockerfile
@@ -39,4 +39,7 @@ WORKDIR /root/rpmbuild
 # suse puts the default build dir as /usr/src/rpmbuild
 # to keep everything simple we just change the default
 RUN echo "%_topdir    /root/rpmbuild" > /root/.rpmmacros
+
+ARG PACKAGE
+ENV PACKAGE=${PACKAGE:-containerd.io}
 ENTRYPOINT ["/build-rpm"]

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -89,7 +89,7 @@ cd %{_topdir}/BUILD
 make man
 
 pushd /go/src/%{import_path}
-%define make_containerd(o:) make VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} %{?**};
+%define make_containerd(o:) make VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} %{?**};
 %make_containerd bin/containerd
 /go/src/%{import_path}/bin/containerd --version
 %make_containerd bin/containerd-shim


### PR DESCRIPTION
depends on

- [x] https://github.com/containerd/containerd/pull/3096
- [x] https://github.com/docker/containerd-packaging/pull/89
- [x] https://github.com/docker/containerd-packaging/pull/91

The default is containerd.io

    make deb
    containerd --version
    containerd containerd.io 20190314.103813~b858cfb4 b858cfb41b4f49d93990380faed2af5dd9269ffe

But can be overridden using the PACKAGE variable:

    make PACKAGE=containerd.dev deb
    containerd --version
    containerd containerd.dev 20190314.103813~b858cfb4 b858cfb41b4f49d93990380faed2af5dd9269ffe

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>