### PR TITLE
Bump Golang 1.11.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ def genRPMBuild(String arch, String cmd, String golangImage, String buildImage) 
 
 def windowsBuild() {
 	return ["WINDOWS":{ ->
-			node('windows-1803') {
+			node('windows-1809') {
 				checkout scm
 				try {
 					withCredentials([hubCred]) {
@@ -126,17 +126,17 @@ packageLookup = [
 ]
 
 golangRPMImages = [
-	"fedora-27": "golang:1.10.8",
-	"fedora-28": "golang:1.10.8",
-	"centos-7": "dockereng/go-crypto-swap:centos-7-go1.10.8",
-	"sles": "dockereng/go-crypto-swap:sles-12.3-go1.10.8",
+	"fedora-27": "golang:1.11.5",
+	"fedora-28": "golang:1.11.5",
+	"centos-7": "dockereng/go-crypto-swap:centos-7-go1.11.5",
+	"sles": "dockereng/go-crypto-swap:sles-12.3-go1.11.5",
 ]
 
 buildSteps = [:]
 for (rpm in rpms) {
 	arches = packageLookup[rpm]
 	for (arch in arches) {
-		golangImage = "golang:1.10.8"
+		golangImage = "golang:1.11.5"
 		buildImage = rpm.replaceAll('-', ':')
 		if (rpm == 'sles') {
 			buildImage = "dockereng/sles:12.3"
@@ -153,10 +153,10 @@ for (rpm in rpms) {
 
 arches = packageLookup["deb"]
 for (arch in arches) {
-	golangImage = "golang:1.10.8"
+	golangImage = "golang:1.11.5"
 	buildImage = "ubuntu:bionic"
 	if (arch == "x86_64") {
-		golangImage = "dockereng/go-crypto-swap:ubuntu-18.04-go1.10.8"
+		golangImage = "dockereng/go-crypto-swap:ubuntu-18.04-go1.11.5"
 		buildImage = golangImage
 	}
 	buildSteps << genDEBBuild(arch, "deb", golangImage, buildImage)

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 ARCH:=$(shell uname -m)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=6635b4f0c6af3810594d2770f662f34ddc15b40d
-GOVERSION?=1.10.8
-GOLANG_IMAGE?=golang:1.10.8
+GOVERSION?=1.11.5
+GOLANG_IMAGE?=golang:1.11.5
 
 # need specific repos for s390x
 ifeq ($(ARCH),s390x)
@@ -42,7 +42,7 @@ CONTAINERD_BRANCH?=release/1.2
 CONTAINERD_DIR?=$(shell basename $(CONTAINERD_REPO))
 CONTAINERD_MOUNT?=C:\gopath\src\github.com\containerd\containerd
 WINDOWS_BINARIES=containerd ctr
-WIN_CRYPTO=dockereng/go-crypto-swap:windows-go1.10.8
+WIN_CRYPTO=dockereng/go-crypto-swap:windows-go1.11.5
 
 # Build tags seccomp and apparmor are needed by CRI plugin.
 BUILDTAGS ?= seccomp apparmor

--- a/scripts/gen-go-dl-url
+++ b/scripts/gen-go-dl-url
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GOVERSION=${GOVERSION:-1.10.8}
+GOVERSION=${GOVERSION:-1.11.5}
 HOST_ARCH=${HOST_ARCH:-$(uname -m)}
 DL_ARCH=${HOST_ARCH}
 


### PR DESCRIPTION
see https://github.com/containerd/containerd/pull/3077

Go 1.12 was released, with which Go 1.10 reached end of support, so let's update this release branch to test against Go 1.11 (Go 1.12 still has some issues, but we could update to Go 1.12.1 once that's released)
