### PR TITLE
Build Pi Zero compatible deb package for raspbian

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ def images = [
     [image: "fedora:30",    arches: arches - ["armhf"]],
     [image: "fedora:29",    arches: arches - ["armhf"]],
     [image: "opensuse/leap:15", arches: arches - ["armhf", "aarch64"]],
+    [image: "resin/rpi-raspbian:stretch",   arches: arches - ["amd64", "aarch64"]],
     [image: "WINDOWS",			arches: ["1809"]],
 ]
 


### PR DESCRIPTION
I tried to install Docker CE 19.03.0-beta1 on a Raspberry Pi Zero.
Since Docker 18.09 this do not work on this ARMv6 CPU.

I investigated what might be missing and tried to build the containerd.io deb package on a Raspberry Pi 2 with the following small difference using a Rasbpian base image to build it.

```
make GOLANG_IMAGE=golang:1.11.5 BUILD_IMAGE=resin/rpi-raspbian:stretch REF=v1.2.5 deb
```

Then I installed the deb package before updating to docker-ce 19.03.0-beta1

And hey it works:

![Docker 19.03.0-beta1 on a Raspberry Pi Zero W](https://user-images.githubusercontent.com/207759/55687107-70c66880-5969-11e9-9fcc-4fcd70f3939f.png)

I started some containers, also docker/surprise works 👍 

As containerd 1.2.6 is around the corner it would be very helpful to have a raspbian specific deb package with this small change in the build to make it compatible for all Raspberry Pi's again.

The difficult part for me is, I don't know how the packages are deployed to the `https://download.docker.com/linux/raspbian stretch/test armhf` repo.

So this PR is only a first starting point. 
