### PR TITLE
new-rpm-release: fix sed error on macOS

### DIFF
--- a/scripts/new-rpm-release
+++ b/scripts/new-rpm-release
@@ -34,4 +34,4 @@ cleanup() {
 
 trap cleanup EXIT
 
-sed -i '/%changelog/ r rpm/new.changelog' rpm/containerd.spec
+sed -i'' -e '/%changelog/ r rpm/new.changelog' rpm/containerd.spec


### PR DESCRIPTION
```bash
./scripts/new-rpm-release v1.2.6
3
sed: -i may not be used with stdin
```

