### PR TITLE
 Release containerd 1.2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 ARCH:=$(shell uname -m)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
-RUNC_REF?=2b18fe1d885ee5083ef9f0838fee39b62d653e30
+RUNC_REF?=029124da7af7360afa781a0234d1b083550f797c
 GOVERSION?=1.11.8
 GOLANG_IMAGE?=golang:1.11.8
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+containerd.io (1.2.6-1) release; urgency=medium
+
+  * containerd 1.2.6 release
+  * update runc to 029124da7af7360afa781a0234d1b083550f797c
+  * build with Go 1.11.8
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Wed, 9 Apr 2019 19:19:23 +0000
+
 containerd.io (1.2.5-1) release; urgency=medium
 
   * containerd 1.2.5 release

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -144,6 +144,11 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Tue Apr 09 2019 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.6-3.1
+- containerd 1.2.6 release
+- update runc to 029124da7af7360afa781a0234d1b083550f797c
+- build with Go 1.11.8
+
 * Thu Mar 14 2019  Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.5-3.1
 - containerd 1.2.5 release
 - update runc to 2b18fe1d885ee5083ef9f0838fee39b62d653e30
@@ -167,7 +172,7 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 - containerd 1.2.1 release
 - update runc to 96ec2177ae841256168fcf76954f7177af9446eb
 
-* Tue Nov 27 2018  Sebastiaan van Stijn <thajeztah@docker.com> - v1.2.1-2.0.rc.0.1
+* Tue Nov 27 2018  Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.1-2.0.rc.0.1
 - containerd 1.2.1-rc.0 release
 - update runc to 10d38b660a77168360df3522881e2dc2be5056bd
 


### PR DESCRIPTION
depends on https://github.com/docker/containerd-packaging/pull/89 (commit included in this PR)


- containerd 1.2.6 release
- update runc to 029124da7af7360afa781a0234d1b083550f797c
- build with Go 1.11.8

containerd changelog: https://github.com/containerd/containerd/releases/tag/v1.2.6