### PR TITLE
mv /usr/sbin/runc -> /usr/bin/runc

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -25,6 +25,6 @@ override_dh_auto_install: $(CONTAINERD_BINARIES) bin/runc
 		dest=$$(basename $$binary); \
 		(set -x; install -D -m 0755 $$binary $(INSTALL_DIR)/usr/bin/$$dest); \
 	done
-	install -D -m 0755 bin/runc $(INSTALL_DIR)/usr/sbin/runc
+	install -D -m 0755 bin/runc $(INSTALL_DIR)/usr/bin/runc
 	install -D -m 0644 /root/common/containerd.service $(INSTALL_DIR)/lib/systemd/system/containerd.service
 	install -D -m 0644 /root/common/containerd.toml $(INSTALL_DIR)/etc/containerd/config.toml

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -135,7 +135,7 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 %{_bindir}/containerd
 %{_bindir}/containerd-shim
 %{?with_ctr:%{_bindir}/ctr}
-%{_sbindir}/runc
+%{_bindir}/runc
 %{_unitdir}/containerd.service
 %{_sysconfdir}/containerd
 /%{_mandir}/man1/*


### PR DESCRIPTION
# Why is this necessary? 

Well because `container-selinux` only runs `restorecon` on certain directories and apparently misses out on `/usr/sbin/runc`,

```
$ rpm -q --scripts container-selinux|grep restorecon
    /usr/sbin/restorecon -R /usr/bin/*podman* /usr/bin/*runc* /usr/bin/*crio /usr/bin/docker* /var/run/containerd.sock /var/run/docker.sock /var/run/docker.pid /etc/docker /etc/crio /var/log/docker /var/log/lxc /var/lock/lxc /usr/lib/systemd/system/docker.service /usr/lib/systemd/system/docker-containerd.service /usr/lib/systemd/system/docker-latest.service /usr/lib/systemd/system/docker-latest-containerd.service /etc/docker /usr/libexec/docker* &> /dev/null || :
    restorecon -R /var/lib/docker &> /dev/null || :
matchpathcon -qV /var/lib/containers || restorecon -R /var/lib/containers &> /dev/null || :
/usr/sbin/restorecon -R /usr/bin/*podman* /usr/bin/*runc* /usr/bin/*crio /usr/bin/docker* /var/run/containerd.sock /var/run/docker.sock /var/run/docker.pid /etc/docker /etc/crio /var/log/docker /var/log/lxc /var/lock/lxc /usr/lib/systemd/system/docker.service /usr/lib/systemd/system/docker-containerd.service /usr/lib/systemd/system/docker-latest.service /usr/lib/systemd/system/docker-latest-containerd.service /etc/docker /usr/libexec/docker* &> /dev/null || :
```

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>