### PR TITLE
Containerd 1.2.8, Golang 1.12.9

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -1,7 +1,7 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=425e105d5a03fabd737a126ad93d62a9eeede87f
-GOVERSION?=1.11.13
+GOVERSION?=1.12.9
 GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)
 BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.2.8-1) release; urgency=medium
+
+  * containerd 1.2.8 release
+  * build with Go 1.12.9
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Mon, 27 Aug 2019 22:40:56 +0000
+
 containerd.io (1.2.6-4) release; urgency=high
 
   * build with Go 1.11.13 (CVE-2019-9512, CVE-2019-9514)

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -154,6 +154,10 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Mon Aug 27 2019  Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.8-3.1
+- containerd 1.2.8 release
+- build with Go 1.12.9
+
 * Thu Aug 15 2019 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.6-3.5
 - build with Go 1.11.13 (CVE-2019-9512, CVE-2019-9514)
 

--- a/scripts/gen-go-dl-url
+++ b/scripts/gen-go-dl-url
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GOVERSION=${GOVERSION:-1.11.13}
+GOVERSION=${GOVERSION:-1.12.9}
 HOST_ARCH=${HOST_ARCH:-$(uname -m)}
 DL_ARCH=${HOST_ARCH}
 


### PR DESCRIPTION
~built on top of https://github.com/docker/containerd-packaging/pull/94~


  * containerd 1.2.8 release
  * build with Go 1.12.9

containerd changelog: https://github.com/containerd/containerd/releases/tag/v1.2.8
containerd changelog: https://github.com/containerd/containerd/releases/tag/v1.2.7