### PR TITLE
Bump golang 1.11.13 (CVE-2019-9512, CVE-2019-9514) ENGCORE-942

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -7,9 +7,9 @@ BUILD=docker build \
 
 CONTAINERD_MOUNT?=C:\gopath\src\github.com\containerd\containerd
 WINDOWS_BINARIES=containerd ctr
-WIN_CRYPTO=dockereng/go-crypto-swap:windows-go1.11.8
+WIN_CRYPTO=dockereng/go-crypto-swap:windows-go$(GOVERSION)
 
-	# Build tags seccomp and apparmor are needed by CRI plugin.
+# Build tags seccomp and apparmor are needed by CRI plugin.
 BUILDTAGS ?= seccomp apparmor
 GO_TAGS=$(if $(BUILDTAGS),-tags "$(BUILDTAGS)",)
 GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)'

--- a/common/common.mk
+++ b/common/common.mk
@@ -1,7 +1,7 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=425e105d5a03fabd737a126ad93d62a9eeede87f
-GOVERSION?=1.11.8
+GOVERSION?=1.11.13
 GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)
 BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.2.6-4) release; urgency=high
+
+  * build with Go 1.11.13 (CVE-2019-9512, CVE-2019-9514)
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com> Thu, 15 Aug 2019 21:02:17 +0000
+
 containerd.io (1.2.6-3) release; urgency=medium
 
   * move runc from /usr/sbin to /usr/bin

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -154,6 +154,9 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Thu Aug 15 2019 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.6-3.5
+- build with Go 1.11.13 (CVE-2019-9512, CVE-2019-9514)
+
 * Tue Aug 13 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.6-3.4
 - Do not "Provides: runc" for RHEL 8
 

--- a/scripts/gen-go-dl-url
+++ b/scripts/gen-go-dl-url
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GOVERSION=${GOVERSION:-1.11.8}
+GOVERSION=${GOVERSION:-1.11.13}
 HOST_ARCH=${HOST_ARCH:-$(uname -m)}
 DL_ARCH=${HOST_ARCH}
 


### PR DESCRIPTION
[ENGCORE-942]
replaces https://github.com/docker/containerd-packaging/pull/94
closes https://github.com/docker/containerd-packaging/pull/94

go1.11.13 (released 2019/08/13) includes security fixes to the net/http and net/url packages.
See the Go 1.11.13 milestone on our issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.11.13

- net/http: Denial of Service vulnerabilities in the HTTP/2 implementation
  net/http and golang.org/x/net/http2 servers that accept direct connections from untrusted
  clients could be remotely made to allocate an unlimited amount of memory, until the program
  crashes. Servers will now close connections if the send queue accumulates too many control
  messages.
  The issues are CVE-2019-9512 and CVE-2019-9514, and Go issue golang.org/issue/33606.
  Thanks to Jonathan Looney from Netflix for discovering and reporting these issues.
  This is also fixed in version v0.0.0-20190813141303-74dc4d7220e7 of golang.org/x/net/http2.
  net/url: parsing validation issue
- url.Parse would accept URLs with malformed hosts, such that the Host field could have arbitrary
  suffixes that would appear in neither Hostname() nor Port(), allowing authorization bypasses
  in certain applications. Note that URLs with invalid, not numeric ports will now return an error
  from url.Parse.
  The issue is CVE-2019-14809 and Go issue golang.org/issue/29098.
  Thanks to Julian Hector and Nikolai Krein from Cure53, and Adi Cohen (adico.me) for discovering
  and reporting this issue.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

[ENGCORE-942]: https://docker.atlassian.net/browse/ENGCORE-942