### PR TITLE
bump changelogs for containerd 1.2.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+containerd.io (1.2.9-1) release; urgency=high
+
+  * containerd 1.2.9 release
+  * Addresses CVE-2019-9512 (Ping Flood), CVE-2019-9514 (Reset Flood), and
+    CVE-2019-9515 (Settings Flood).
+
+ -- Eli Uriegas <eli.uriegas@docker.com>  Fri, 06 Sep 2019 20:04:44 +0000
+
 containerd.io (1.2.8-1) release; urgency=medium
 
   * containerd 1.2.8 release

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -154,7 +154,11 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
-* Mon Aug 27 2019  Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.8-3.1
+* Fri Sep 06 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.9-3.1
+- containerd 1.2.9 release
+- Addresses CVE-2019-9512 (Ping Flood), CVE-2019-9514 (Reset Flood), and CVE-2019-9515 (Settings Flood).
+
+* Mon Aug 27 2019 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.8-3.1
 - containerd 1.2.8 release
 - build with Go 1.12.9
 


### PR DESCRIPTION
Am going to to try and release this version on Monday 9/9/2019 with the new system.

Created with:
```
$ ./scripts/new-deb-release 1.2.9
$ ./scripts/new-rpm-release 1.2.9
```

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>