### PR TITLE
build: Stop removing CONTAINERD_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ clean:
 	-$(CHOWN_TO_USER) build/
 	-$(RM) -r build/
 	-$(RM) -r artifacts
-	-$(RM) -r $(CONTAINERD_DIR)
 
 .PHONY: build
 build:


### PR DESCRIPTION
It shouldn't in the clean since it could potentially be a directory someone is working in like `~/go/src/github.com/containerd/containerd`

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>