### PR TITLE
WIP Remove runc binary building, add runc.io dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,6 @@ ifdef CONTAINERD_DIR
 	VOLUME_MOUNTS+=-v "$(shell realpath $(CONTAINERD_DIR)):/go/src/github.com/containerd/containerd"
 endif
 
-ifdef RUNC_DIR
-	VOLUME_MOUNTS+=-v "$(shell realpath $(RUNC_DIR)):/go/src/github.com/opencontainers/runc"
-endif
-
 ENV_VARS=
 ifdef CREATE_ARCHIVE
 	ENV_VARS+=-e CREATE_ARCHIVE=1

--- a/debian/changelog
+++ b/debian/changelog
@@ -25,6 +25,8 @@ containerd.io (1.2.9-1) release; urgency=high
   * containerd 1.2.9 release
   * Addresses CVE-2019-9512 (Ping Flood), CVE-2019-9514 (Reset Flood), and
     CVE-2019-9515 (Settings Flood).
+  * Removed runc binary
+  * Added new dependency on runc.io
 
  -- Eli Uriegas <eli.uriegas@docker.com>  Fri, 06 Sep 2019 20:04:44 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -15,8 +15,9 @@ XS-Go-Import-Path: github.com/containerd/containerd
 Package: containerd.io
 Architecture: any
 Depends: ${misc:Depends},
-         ${shlibs:Depends}
-Provides: containerd, runc
-Conflicts: containerd, runc
-Replaces: containerd, runc
+         ${shlibs:Depends},
+         runc.io
+Provides: containerd
+Conflicts: containerd
+Replaces: containerd
 Description: An open and reliable container runtime

--- a/debian/rules
+++ b/debian/rules
@@ -14,20 +14,16 @@ bin/%: ## Create containerd binaries
 	mkdir -p $(@D)
 	mv -v $(GO_SRC_PATH)/$@ $@
 
-bin/runc:
-	make -C /go/src/github.com/opencontainers/runc BUILDTAGS='seccomp apparmor selinux' runc && mv -v /go/src/github.com/opencontainers/runc/runc $@
-
 override_dh_auto_build: $(CONTAINERD_BINARIES)
 
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade
 
-override_dh_auto_install: $(CONTAINERD_BINARIES) bin/runc
+override_dh_auto_install: $(CONTAINERD_BINARIES)
 	# set -x so we can see what's being installed where
 	for binary in $(CONTAINERD_BINARIES); do \
 		dest=$$(basename $$binary); \
 		(set -x; install -D -m 0755 $$binary $(INSTALL_DIR)/usr/bin/$$dest); \
 	done
-	install -D -m 0755 bin/runc $(INSTALL_DIR)/usr/bin/runc
 	install -D -m 0644 /root/common/containerd.service $(INSTALL_DIR)/lib/systemd/system/containerd.service
 	install -D -m 0644 /root/common/containerd.toml $(INSTALL_DIR)/etc/containerd/config.toml

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -19,11 +19,6 @@ RUN mkdir -p ${GO_SRC_PATH}
 RUN git clone https://${IMPORT_PATH} ${GO_SRC_PATH}
 RUN git -C ${GO_SRC_PATH} checkout ${REF}
 
-ARG RUNC_REF=master
-RUN mkdir -p /go/src/github.com/opencontainers/runc
-RUN git clone https://github.com/opencontainers/runc.git /go/src/github.com/opencontainers/runc
-RUN git -C /go/src/github.com/opencontainers/runc checkout ${RUNC_REF}
-
 # Set up debian packaging files
 RUN mkdir -p /root/containerd
 COPY debian/ /root/containerd/debian

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -10,12 +10,6 @@ ARG REF=master
 RUN git clone https://github.com/containerd/containerd.git /containerd
 RUN git -C /containerd checkout ${REF}
 
-FROM alpine:3.8 as runc
-RUN apk -u --no-cache add git
-ARG RUNC_REF=master
-RUN git clone https://github.com/opencontainers/runc.git /runc
-RUN git -C /runc checkout ${RUNC_REF}
-
 FROM ${BUILD_IMAGE} as redhat-base
 RUN yum install -y yum-utils rpm-build git
 
@@ -57,7 +51,6 @@ RUN mkdir -p /go
 ARG REF
 ENV GO_SRC_PATH /go/src/github.com/containerd/containerd
 COPY --from=containerd /containerd /go/src/github.com/containerd/containerd
-COPY --from=runc /runc /go/src/github.com/opencontainers/runc
 
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/build-rpm"]

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -26,22 +26,15 @@ AutoReq: no
 %define SHA256SUM0 08f057ece7e518b14cce2e9737228a5a899a7b58b78248a03e02f4a6c079eeaf
 %global import_path github.com/containerd/containerd
 %global gopath %{getenv:GOPATH}
-%global runc_nokmem %{getenv:RUNC_NOKMEM}
 
 Name: containerd.io
 Provides: containerd
-# For some reason on rhel 8 if we "provide" runc then it makes this package unsearchable
-%if 0%{!?el8:1}
-Provides: runc
-%endif
 
 # Obsolete packages
 Obsoletes: containerd
-Obsoletes: runc
 
 # Conflicting packages
 Conflicts: containerd
-Conflicts: runc
 
 Version: %{getenv:RPM_VERSION}
 Release: %{getenv:RPM_RELEASE_VERSION}%{?dist}
@@ -51,7 +44,8 @@ URL: https://containerd.io
 Source0: containerd
 Source1: containerd.service
 Source2: containerd.toml
-Source3: runc
+
+Requires: runc.io
 # container-selinux isn't a thing in suse flavors
 %if %{undefined suse_version}
 # amazonlinux2 doesn't have container-selinux either
@@ -89,8 +83,6 @@ rm -rf %{_topdir}/BUILD/
 cp -rf /go/src/%{import_path} %{_topdir}/SOURCES/containerd
 # symlink the go source path to our build directory
 ln -s /go/src/%{import_path} %{_topdir}/BUILD
-# Copy over our source code from our gopath to our source directory
-cp -rf /go/src/github.com/opencontainers/runc %{_topdir}/SOURCES/runc
 cd %{_topdir}/BUILD/
 
 
@@ -107,10 +99,6 @@ pushd /go/src/%{import_path}
 /go/src/%{import_path}/bin/ctr --version
 popd
 
-pushd /go/src/github.com/opencontainers/runc
-make BUILDTAGS='seccomp apparmor selinux %{runc_nokmem}' runc
-popd
-
 
 %install
 cd %{_topdir}/BUILD
@@ -119,7 +107,6 @@ install -D -m 0755 bin/containerd-shim %{buildroot}%{_bindir}/containerd-shim
 install -D -m 0755 bin/ctr %{buildroot}%{_bindir}/ctr
 install -D -m 0644 %{S:1} %{buildroot}%{_unitdir}/containerd.service
 install -D -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
-install -D -m 0755 /go/src/github.com/opencontainers/runc/runc %{buildroot}%{_bindir}/runc
 
 # install manpages
 install -d %{buildroot}%{_mandir}/man1
@@ -145,7 +132,6 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 %{_bindir}/containerd
 %{_bindir}/containerd-shim
 %{?with_ctr:%{_bindir}/ctr}
-%{_bindir}/runc
 %{_unitdir}/containerd.service
 %{_sysconfdir}/containerd
 /%{_mandir}/man1/*
@@ -165,6 +151,8 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 * Fri Sep 06 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.9-3.1
 - containerd 1.2.9 release
 - Addresses CVE-2019-9512 (Ping Flood), CVE-2019-9514 (Reset Flood), and CVE-2019-9515 (Settings Flood).
+- Removed runc binary
+- Added dependency on runc.io
 
 * Mon Aug 27 2019 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.8-3.1
 - containerd 1.2.8 release

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -142,6 +142,8 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 %changelog
 * Mon Oct 07 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.10-3.2
 - build with Go 1.12.10
+- Removed runc binary
+- Added dependency on runc.io
 
 * Thu Sep 26 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.10-3.1
 - containerd 1.2.10 release
@@ -151,8 +153,6 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 * Fri Sep 06 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.9-3.1
 - containerd 1.2.9 release
 - Addresses CVE-2019-9512 (Ping Flood), CVE-2019-9514 (Reset Flood), and CVE-2019-9515 (Settings Flood).
-- Removed runc binary
-- Added dependency on runc.io
 
 * Mon Aug 27 2019 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.8-3.1
 - containerd 1.2.8 release


### PR DESCRIPTION
We can successfully build/release binaries now for `runc.io`! 

This is more of a POC to show that we can actually do this and not necessarily something we should merge in just yet.