### PR TITLE
bump to containerd 1.2.10-2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,14 @@
+containerd.io (1.2.10-2) release; urgency=high
+
+  * build with Go 1.12.10
+
+ -- Eli Uriegas <eli.uriegas@docker.com>  Mon, 07 Oct 2019 23:57:42 +0000
+
 containerd.io (1.2.10-1) release; urgency=high
 
   * containerd 1.2.10 release
   * Bump runc to 3e425f80a8c931f88e6d94a8c831b9d5aa481657 (1.0.0-rc8 + CVE-2019-16884)
   * Addresses CVE-2019-16884 (AppArmor bypass)
-  * build with Go 1.12.10
 
  -- Eli Uriegas <eli.uriegas@docker.com>  Thu, 26 Sep 2019 20:58:57 +0000
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -154,11 +154,13 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Mon Oct 07 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.10-3.2
+- build with Go 1.12.10
+
 * Thu Sep 26 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.10-3.1
 - containerd 1.2.10 release
 - Addresses CVE-2019-16884 (AppArmor bypass)
 - Bump runc to 3e425f80a8c931f88e6d94a8c831b9d5aa481657 (1.0.0-rc8 + CVE-2019-16884)
-- build with Go 1.12.10
 
 * Fri Sep 06 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.9-3.1
 - containerd 1.2.9 release


### PR DESCRIPTION
To encompass actually building the packages with go `1.12.10`

master builds are currently failing due to https://github.com/containerd/containerd/pull/3729