### PR TITLE
[DO NOT MERGE] make sure containerd runs with all libseccomp versions

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,22 @@ Source: containerd.io
 Section: devel
 Priority: optional
 Maintainer: Containerd team <help@containerd.io>
+
+# libseccomp-golang commit 9814e55a2e59df39b8ad4fbff1226585ebb84674 started using
+# a new seccomp_version API, which was introduced in libseccomp 2.3 (addded in
+# https://github.com/seccomp/libseccomp/commit/58a7c20). As a result, if the binary
+# is compiled with libseccomp 2.3 or up, the minimum requirement for libseccomp
+# to run the binary will also be libseccomp 2.3.0 (running on a system with an
+# older version of libseccomp, will produce "undefined symbol: seccomp_version")
+#
+# Here, we restrict the version of libseccomp-dev at compile time to 2.2.x, so
+# that the new API isn't used, and that the binary is compatible with libseccomp
+# 2.2.0 and up. Running on a system with
 Build-Depends: libbtrfs-dev | btrfs-tools ,
                debhelper,
                dh-systemd,
                pkg-config,
-               libseccomp-dev
+               libseccomp-dev (<< 2.3.0)
 Standards-Version: 4.1.4
 Homepage: https://containerd.io
 Vcs-Browser: https://github.com/containerd/containerd

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -62,7 +62,18 @@ Requires: container-selinux >= 2:2.74
 BuildRequires: make
 BuildRequires: gcc
 BuildRequires: systemd
-BuildRequires: libseccomp-devel
+
+# libseccomp-golang commit 9814e55a2e59df39b8ad4fbff1226585ebb84674 started using
+# a new seccomp_version API, which was introduced in libseccomp 2.3 (addded in
+# https://github.com/seccomp/libseccomp/commit/58a7c20). As a result, if the binary
+# is compiled with libseccomp 2.3 or up, the minimum requirement for libseccomp
+# to run the binary will also be libseccomp 2.3.0 (running on a system with an
+# older version of libseccomp, will produce "undefined symbol: seccomp_version")
+#
+# Here, we restrict the version of libseccomp-dev at compile time to 2.2.x, so
+# that the new API isn't used, and that the binary is compatible with libseccomp
+# 2.2.0 and up.
+BuildRequires: libseccomp-devel << 2.3.0
 
 # Should only return true if `el8` (rhel8) is NOT defined
 %if 0%{!?el8:1}


### PR DESCRIPTION
### This is just to discuss the issue, and to discuss possible approaches

libseccomp-golang https://github.com/seccomp/libseccomp-golang/commit/9814e55a
started using a new seccomp_version API, which was introduced in libseccomp 2.3
(addded in https://github.com/seccomp/libseccomp/commit/58a7c20). As a result,
if the binary is compiled with libseccomp 2.3 or up, the minimum requirement for
libseccomp to run the binary will also be libseccomp 2.3.0 (running on a system
with an older version of libseccomp, will produce "undefined symbol: seccomp_version")

A seccond problem also came up; if the binary is compiled with libseccomp 2.4.0
or up, containerd can only be run with that version (caused by https://github.com/seccomp/libseccomp/commit/e89d18205c7dcd7582f41051cd6389c9b12dfccf), and machines running libseccomp
2.3 or 2.2 will fail with:

```
there's an error: /usr/bin/containerd: undefined symbol: seccomp_api_get
```

The latest containerd has been compiled with libseccomp 2.4.x, and therefore can
only be used on a system that has libseccomp 2.4.

Current libseccomp 2.4.1 is known to have performance issues (due to a refactor),
see https://github.com/seccomp/libseccomp/issues/153 for more details on that.

This PR restricts the version of libseccomp-dev at compile time to 2.2.x, so
that the new API isn't used, and that the binary is compatible with libseccomp
2.2.0 and up.

The `.deb` binaries all look to be compiled with ubuntu:bionic.

> **note** that the base image to build binaries for all .deb packages is currently
> `ubuntu:bionic`, irregardless of the target distro version of the package)

Checking what's currently available:
=========================================

Ubuntu
-----------------------------------------

```bash
docker run --rm ubuntu:xenial sh -c 'apt-get update -qq && apt-cache madison libseccomp-dev'
libseccomp-dev | 2.4.1-0ubuntu0.16.04.2 | http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages
libseccomp-dev | 2.4.1-0ubuntu0.16.04.2 | http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages
libseccomp-dev | 2.2.3-3ubuntu3 | http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages

docker run --rm ubuntu:bionic sh -c 'apt-get update -qq && apt-cache madison libseccomp-dev'
libseccomp-dev | 2.4.1-0ubuntu0.18.04.2 | http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages
libseccomp-dev | 2.4.1-0ubuntu0.18.04.2 | http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages
libseccomp-dev | 2.3.1-2.1ubuntu4 | http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages
```

Debian
-----------------------------------------

```bash
docker run --rm debian:stretch sh -c 'apt-get update -qq && apt-cache madison libseccomp-dev'
libseccomp-dev | 2.3.1-2.1+deb9u1 | http://deb.debian.org/debian stretch/main amd64 Packages

docker run --rm debian:buster sh -c 'apt-get update -qq && apt-cache madison libseccomp-dev'
libseccomp-dev |    2.3.3-4 | http://deb.debian.org/debian buster/main amd64 Packages
```

RHEL/CentOS
-----------------------------------------

Note that RHEL 8 and CentOS 8 no longer have libseccomp-devel in the default repositories;
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index

> The following packages are distributed in the Base channel of RHEL 7 and in RHEL 8 they are a part of the CodeReady Linux Builder repository:
>
> ...
> - libseccomp-devel

The "CodeReady Linux Builder" is for RHEL; the CentOS equivalent for that is the PowerTools repo

```bash
docker run --rm centos:7 sh -c 'yum --showduplicates list libseccomp-devel'
Available Packages
libseccomp-devel.i686                       2.3.1-3.el7                     base
libseccomp-devel.x86_64                     2.3.1-3.el7                     base

docker run --rm centos:8 sh -c 'yum --enablerepo=PowerTools --showduplicates list libseccomp-devel'

Available Packages
libseccomp-devel.i686                    2.3.3-3.el8                  PowerTools
libseccomp-devel.x86_64                  2.3.3-3.el8                  PowerTools
```

Amazon Linux
-----------------------------------------

```bash
docker run --rm amazonlinux:2 sh -c 'yum --showduplicates list libseccomp-devel'
Available Packages
libseccomp-devel.x86_64               2.3.1-3.amzn2.0.1               amzn2-core
libseccomp-devel.x86_64               2.3.1-3.amzn2.0.3               amzn2-core
```

SUSE
-----------------------------------------

```bash
docker run --rm opensuse/leap:15 sh -c 'zypper search -s libseccomp-devel'

S | Name             | Type    | Version           | Arch   | Repository
--+------------------+---------+-------------------+--------+-----------------------
  | libseccomp-devel | package | 2.4.1-lp151.3.3.1 | x86_64 | Main Update Repository
  | libseccomp-devel | package | 2.3.2-lp151.2.3   | x86_64 | Main Repository
  | libseccomp-devel | package | 2.4.1-lp151.3.3.1 | i586   | Main Update Repository
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>