### PR TITLE
deb pkgs: restart after upgrade TAR-1285

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,9 @@ bin/runc:
 
 override_dh_auto_build: $(CONTAINERD_BINARIES)
 
+override_dh_systemd_start:
+	dh_systemd_start --restart-after-upgrade
+
 override_dh_auto_install: $(CONTAINERD_BINARIES) bin/runc
 	# set -x so we can see what's being installed where
 	for binary in $(CONTAINERD_BINARIES); do \


### PR DESCRIPTION
Based on how I see the script to be used: https://git.launchpad.net/ubuntu/+source/init-system-helpers/tree/script/dh_systemd_start?h=ubuntu/xenial

Related man page from xenial docs: http://manpages.ubuntu.com/manpages/disco/en/man1/dh_installsystemd.1.html

To address [TAR-1285]

[TAR-1285]: https://docker.atlassian.net/browse/TAR-1285