### PR TITLE
[TAR-1285] deb: Replace all instances of try-restart with restart

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,6 +21,7 @@ override_dh_auto_build: $(CONTAINERD_BINARIES)
 
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade
+	sed -i 's/_dh_action=try-restart/_dh_action=restart/g' ./debian/containerd.io.postinst.debhelper
 
 override_dh_auto_install: $(CONTAINERD_BINARIES) bin/runc
 	# set -x so we can see what's being installed where


### PR DESCRIPTION
There was a bug where the containerd service wouldn't start if the `containerd.io` package was previously removed then installed again. This should remedy that.