### PR TITLE
Jenkinsfile: use balenalib/rpi-raspbian (old one was deprecated)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,21 +8,21 @@ def arches = ["amd64", "armhf", "aarch64"]
 // This list is ordered by Distro (alphabetically), and release (chronologically).
 // When adding a distro here, also open a pull request in the release repository.
 def images = [
-    [image: "amazonlinux:2",                arches: arches - ["amd64", "armhf"]],
-    [image: "centos:7",                     arches: arches - ["armhf"]],
-    [image: "debian:stretch",               arches: arches],    // Debian 9 (EOL: June, 2022)
-    [image: "debian:buster",                arches: arches],    // Debian 10 (EOL: 2024)
-    [image: "fedora:29",                    arches: arches - ["armhf"]],
-    [image: "fedora:30",                    arches: arches - ["armhf"]],
-    [image: "fedora:31",                    arches: arches - ["armhf"]],
-    [image: "fedora:latest",                arches: arches - ["armhf"]],
-    [image: "opensuse/leap:15",             arches: arches - ["armhf", "aarch64"]],
-    [image: "resin/rpi-raspbian:stretch",   arches: ["armhf"]],
-    [image: "resin/rpi-raspbian:buster",    arches: ["armhf"]],
-    [image: "ubuntu:xenial",                arches: arches],    // Ubuntu 16.04 LTS (End of support: April, 2021. EOL: April, 2024)
-    [image: "ubuntu:bionic",                arches: arches],    // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
-    [image: "ubuntu:disco",                 arches: arches],    // Ubuntu 19.03  (EOL: January, 2020)
-    [image: "ubuntu:eoan",                  arches: arches],    // Ubuntu 19.10  (EOL: July, 2020)
+    [image: "amazonlinux:2",                  arches: arches - ["amd64", "armhf"]],
+    [image: "centos:7",                       arches: arches - ["armhf"]],
+    [image: "debian:stretch",                 arches: arches],    // Debian 9 (EOL: June, 2022)
+    [image: "debian:buster",                  arches: arches],    // Debian 10 (EOL: 2024)
+    [image: "fedora:29",                      arches: arches - ["armhf"]],
+    [image: "fedora:30",                      arches: arches - ["armhf"]],
+    [image: "fedora:31",                      arches: arches - ["armhf"]],
+    [image: "fedora:latest",                  arches: arches - ["armhf"]],
+    [image: "opensuse/leap:15",               arches: arches - ["armhf", "aarch64"]],
+    [image: "balenalib/rpi-raspbian:stretch", arches: ["armhf"]],
+    [image: "balenalib/rpi-raspbian:buster",  arches: ["armhf"]],
+    [image: "ubuntu:xenial",                  arches: arches],    // Ubuntu 16.04 LTS (End of support: April, 2021. EOL: April, 2024)
+    [image: "ubuntu:bionic",                  arches: arches],    // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
+    [image: "ubuntu:disco",                   arches: arches],    // Ubuntu 19.03  (EOL: January, 2020)
+    [image: "ubuntu:eoan",                    arches: arches],    // Ubuntu 19.10  (EOL: July, 2020)
 ]
 
 // Required for windows


### PR DESCRIPTION
just realised this repo was still using the old images, which were marked "deprecated";

> This repository is deprecated. All resin base images are moved to new namespace "balenalib". Please check our docs(https://www.balena.io/docs) or new dockerhub namespace(https://hub.docker.com/u/balenalib/) for more details.