### PR TITLE
Remove go-crypto-swap build in Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -6,7 +6,7 @@ CONTAINERD_MOUNT?=C:/gopath/src/github.com/containerd/containerd
 # Windows builder, only difference is we installed make
 windows-image:
 	docker build \
-		--build-arg GOVERSION=$(GOVERSION) \
+		--build-arg GOLANG_IMAGE=$(GOLANG_IMAGE) \
 		-t dockereng/containerd-windows-builder \
 		-f dockerfiles/win.dockerfile \
 		.

--- a/dockerfiles/win.dockerfile
+++ b/dockerfiles/win.dockerfile
@@ -1,5 +1,5 @@
-ARG  GOVERSION
-FROM dockereng/go-crypto-swap:windows-go${GOVERSION}
+ARG  GOLANG_IMAGE
+FROM ${GOLANG_IMAGE}
 ENV  chocolateyUseWindowsCompression=false
 # Install make
 RUN  iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \


### PR DESCRIPTION
This should be good for open source use after this.