### PR TITLE
Update packaging to support 1.3.2

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -1,7 +1,7 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
-RUNC_REF?=3e425f80a8c931f88e6d94a8c831b9d5aa481657
-GOVERSION?=1.12.10
+RUNC_REF?=d736ef14f0288d6993a1845745d6756cfc9ddd5a
+GOVERSION?=1.13.5
 GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)
 BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+containerd.io (1.3.2-1) release; urgency=medium
+  * Runtime: Fix containerd pid race condition containerd/containerd#3857
+  * Runtime: Use cached process state to reduce exec cost containerd/containerd#3711
+  * CRI: Added insecure_skip_verify option in the registry tls config to allow
+    skipping registry certificate verification containerd/containerd#3847
+  * Build with Go 1.13.5
+
+ -- Evan Hazlett <evan@docker.com>  Thu, 9 Jan 2020 15:15:56 +0000
+
 containerd.io (1.2.10-3) release; urgency=medium
 
   * Added explicit --restart-after-upgrade to dh_systemd_start due to

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 INSTALL_DIR=debian/containerd.io
-CONTAINERD_BINARIES=bin/containerd bin/containerd-shim bin/ctr
+CONTAINERD_BINARIES=bin/containerd bin/containerd-shim bin/ctr bin/containerd-shim-runc-v1 bin/containerd-shim-runc-v2
 
 %:
 	dh $@ --with systemd

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -103,6 +103,8 @@ pushd /go/src/%{import_path}
 %make_containerd bin/containerd
 /go/src/%{import_path}/bin/containerd --version
 %make_containerd bin/containerd-shim
+%make_containerd bin/containerd-shim-runc-v1
+%make_containerd bin/containerd-shim-runc-v2
 %make_containerd bin/ctr
 /go/src/%{import_path}/bin/ctr --version
 popd
@@ -116,6 +118,8 @@ popd
 cd %{_topdir}/BUILD
 install -D -m 0755 bin/containerd %{buildroot}%{_bindir}/containerd
 install -D -m 0755 bin/containerd-shim %{buildroot}%{_bindir}/containerd-shim
+install -D -m 0755 bin/containerd-shim-runc-v1 %{buildroot}%{_bindir}/containerd-shim-runc-v1
+install -D -m 0755 bin/containerd-shim-runc-v2 %{buildroot}%{_bindir}/containerd-shim-runc-v2
 install -D -m 0755 bin/ctr %{buildroot}%{_bindir}/ctr
 install -D -m 0644 %{S:1} %{buildroot}%{_unitdir}/containerd.service
 install -D -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
@@ -144,6 +148,8 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 %doc README.md
 %{_bindir}/containerd
 %{_bindir}/containerd-shim
+%{_bindir}/containerd-shim-runc-v1
+%{_bindir}/containerd-shim-runc-v2
 %{?with_ctr:%{_bindir}/ctr}
 %{_bindir}/runc
 %{_unitdir}/containerd.service
@@ -154,6 +160,13 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Thu Jan 09 2020 Evan Hazlett <evan@docker.com> - 1.3.2-3.1
+- Runtime: Fix containerd pid race condition containerd/containerd#3857
+- Runtime: Use cached process state to reduce exec cost containerd/containerd#3711
+- CRI: Added insecure_skip_verify option in the registry tls config to allow
+  skipping registry certificate verification containerd/containerd#3847
+- Build with Go 1.13.5
+
 * Mon Oct 07 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.10-3.2
 - build with Go 1.12.10
 


### PR DESCRIPTION
Tested so far on Ubuntu (I have to get some RPM distros up still).

```
$> apt install -y ./containerd.io_1.3.2-1_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'containerd.io' instead of './containerd.io_1.3.2-1_amd64.deb'
The following NEW packages will be installed:
  containerd.io
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/25.0 MB of archives.
After this operation, 118 MB of additional disk space will be used.
Get:1 /root/build/ubuntu/eoan/amd64/containerd.io_1.3.2-1_amd64.deb containerd.io amd64 1.3.2-1 [25.0 MB]
Selecting previously unselected package containerd.io.
(Reading database ... 62528 files and directories currently installed.)
Preparing to unpack .../containerd.io_1.3.2-1_amd64.deb ...
Unpacking containerd.io (1.3.2-1) ...
Setting up containerd.io (1.3.2-1) ...
Created symlink /etc/systemd/system/multi-user.target.wants/containerd.service → /lib/systemd/system/containerd.service.
```

```
$> containerd --version
containerd containerd.io 1.3.2 ff48f57fc83a8c44cf4ad5d672424a98ba37ded6
```

```
Package: containerd.io
Status: install ok installed
Priority: optional
Section: devel
Installed-Size: 115562
Maintainer: Containerd team <help@containerd.io>
Architecture: amd64
Version: 1.3.2-1
Replaces: containerd, runc
Provides: containerd, runc
Depends: libc6 (>= 2.14), libseccomp2 (>= 2.4.0)
Conflicts: containerd, runc
Conffiles:
 /etc/containerd/config.toml 417033b466af4a9c58e3fc5842303008
Description: An open and reliable container runtime
Description-md5: b760064be8ea75804c76adda8f7a6c49
Homepage: https://containerd.io
```

```
$> ctr run -t --rm docker.io/library/busybox:latest shell echo ohai
ohai
```