### PR TITLE
Remove go-crypto-swap

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -6,7 +6,7 @@ CONTAINERD_MOUNT?=C:/gopath/src/github.com/containerd/containerd
 # Windows builder, only difference is we installed make
 windows-image:
 	docker build \
-		--build-arg GOVERSION=$(GOVERSION) \
+		--build-arg GOLANG_IMAGE=$(GOLANG_IMAGE) \
 		-t dockereng/containerd-windows-builder \
 		-f dockerfiles/win.dockerfile \
 		.

--- a/dockerfiles/win.dockerfile
+++ b/dockerfiles/win.dockerfile
@@ -1,7 +1,7 @@
-ARG  GOVERSION
-FROM dockereng/go-crypto-swap:windows-go${GOVERSION}
+ARG  GOLANG_IMAGE
+FROM ${GOLANG_IMAGE}
 ENV  chocolateyUseWindowsCompression=false
-# Install make
+# Install make and gcc
 RUN  iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
      choco feature disable --name showDownloadProgress; \
-     choco install -y make
+     choco install -y make mingw


### PR DESCRIPTION
Based on #123, I installed `gcc` with the `mingw` choco package.

The `containerd.exe` file has two DLL dependencies, kernel32.dll and msvcrt.dll, so it looks good.

<img width="393" alt="containerd.exe dependencies" src="https://user-images.githubusercontent.com/207759/72813678-0ebec180-3c64-11ea-8278-9e549aa7a498.png">

Funny, on Windows 10 machine I couldn't compile the exefile in the build-container. I went back to my Mac and spun up my Windows Docker machine and worked from my Mac 😄 OK, the difference might be the Windows VM is a Windows Server 2019 and not a Windows 10 Insider.
