### PR TITLE
Build binary with .exe extension

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -20,7 +20,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:$(CONTAINERD_MOUNT)/bin" \
 		-w "$(CONTAINERD_MOUNT)" \
 		dockereng/containerd-windows-builder \
-		make bin/$*
+		make bin/$*.exe
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'


### PR DESCRIPTION
Fixes the build error in https://ci.docker.com/teams-core/job/release-packaging/job/PR-477/2/execution/node/514/log/

With that change the two binaries are created with `.exe` extension and the zip file will be created.


@thaJeztah PTAL