### PR TITLE
update golang to 1.12.15

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -1,7 +1,7 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=d736ef14f0288d6993a1845745d6756cfc9ddd5a
-GOVERSION?=1.12.13
+GOVERSION?=1.12.15
 GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)
 BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.2.11-2) release; urgency=medium
+
+  * Update Golang runtime to 1.12.15, which includes fixes in the net/http package
+    and the runtime on ARM64
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>
+
 containerd.io (1.2.11-1) release; urgency=medium
 
   * Update the runc vendor to v1.0.0-rc9 which includes an additional

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -154,6 +154,10 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Fri Jan 24 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.11-3.2
+- Update Golang runtime to 1.12.15, which includes fixes in the net/http package
+  and the runtime on ARM64
+
 * Thu Jan 09 2020 Evan Hazlett <evan@docker.com> - 1.2.11-3.1
 - Update the runc vendor to v1.0.0-rc9 which includes an additional
   mitigation for CVE-2019-16884
@@ -163,7 +167,6 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
   crypto/dsa package made in Go 1.12.11 (CVE-2019-17596), and fixes to the
   go command, runtime, syscall and net packages (Go 1.12.12)
 - CRI: Fix shim delete error code to avoid unnecessary retries in the CRI plugin
-- build with Go 1.12.13
 
 * Mon Oct 07 2019 Eli Uriegas <eli.uriegas@docker.com> - 1.2.10-3.2
 - build with Go 1.12.10

--- a/scripts/gen-go-dl-url
+++ b/scripts/gen-go-dl-url
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GOVERSION=${GOVERSION:-1.12.10}
+GOVERSION=${GOVERSION:-1.12.15}
 HOST_ARCH=${HOST_ARCH:-$(uname -m)}
 DL_ARCH=${HOST_ARCH}
 


### PR DESCRIPTION
Update Golang 1.12.15
---------------------------

full diff: https://github.com/golang/go/compare/go1.12.14...go1.12.15
go1.12.15 (released 2020/01/09) includes fixes to the runtime and the net/http
package. See the Go 1.12.15 milestone on the issue tracker for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.12.15+label%3ACherryPickApproved

Update Golang 1.12.14
---------------------------

go1.12.14 (released 2019/12/04) includes a fix to the runtime. See the Go 1.12.14
milestone on our issue tracker for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.12.14+label%3ACherryPickApproved
