### PR TITLE
Make new-rpm-release script work on macOS

### DIFF
--- a/scripts/new-rpm-release
+++ b/scripts/new-rpm-release
@@ -28,8 +28,9 @@ EOF
 
 cleanup() {
     rm rpm/new.changelog
+    rm "${SPEC_FILE}.bak"
 }
 
 trap cleanup EXIT
 
-sed -i '/%changelog/ r rpm/new.changelog' "${SPEC_FILE}"
+sed -i'.bak' '/%changelog/ r rpm/new.changelog' "${SPEC_FILE}"


### PR DESCRIPTION
Works around a difference in the macOS version of sed,
which caused this error;

    sed: -i may not be used with stdin

