### PR TITLE
Revert "Build binary with .exe extension"

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -20,7 +20,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:$(CONTAINERD_MOUNT)/bin" \
 		-w "$(CONTAINERD_MOUNT)" \
 		dockereng/containerd-windows-builder \
-		make bin/$*.exe
+		make bin/$*
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'


### PR DESCRIPTION
This reverts PR #128 as it breaks building containerd 1.2.11 https://ci.docker.com/teams-core/job/release-packaging/job/containerd/33/ 

When building containerd master branch we need that change in #128 as https://github.com/containerd/containerd/pull/3823 seems to be the relevant change in containerd/containerd repo.

