### PR TITLE
release 1.2.11-3 - update golang 1.12.16

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -1,7 +1,7 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=d736ef14f0288d6993a1845745d6756cfc9ddd5a
-GOVERSION?=1.12.15
+GOVERSION?=1.12.16
 GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)
 BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+containerd.io (1.2.11-3) release; urgency=medium
+
+  * Update Golang runtime to 1.12.16, mitigating the CVE-2020-0601 certificate
+    verification bypass on Windows, and CVE-2020-7919, which only affects
+    32-bit architectures.
+
+ -- Sebastiaan van Stijn <github@gone.nl>  
+
 containerd.io (1.2.11-2) release; urgency=medium
 
   * Update Golang runtime to 1.12.15, which includes fixes in the net/http package

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -154,6 +154,11 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Thu Jan 30 2020 Sebastiaan van Stijn <github@gone.nl> - 1.2.11-3.3
+- Update Golang runtime to 1.12.16, mitigating the CVE-2020-0601 certificate
+  verification bypass on Windows, and CVE-2020-7919, which only affects
+  32-bit architectures.
+
 * Fri Jan 24 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.11-3.2
 - Update Golang runtime to 1.12.15, which includes fixes in the net/http package
   and the runtime on ARM64

--- a/scripts/gen-go-dl-url
+++ b/scripts/gen-go-dl-url
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GOVERSION=${GOVERSION:-1.12.15}
+GOVERSION=${GOVERSION:-1.12.16}
 HOST_ARCH=${HOST_ARCH:-$(uname -m)}
 DL_ARCH=${HOST_ARCH}
 


### PR DESCRIPTION
Update Golang 1.12.16 (CVE-2020-0601, CVE-2020-7919)

full diff: https://github.com/golang/go/compare/go1.12.15...go1.12.16

go1.12.16 (released 2020/01/28) includes two security fixes. One mitigates the
CVE-2020-0601 certificate verification bypass on Windows. The other affects only
32-bit architectures.

https://github.com/golang/go/issues?q=milestone%3AGo1.12.16+label%3ACherryPickApproved

- X.509 certificate validation bypass on Windows 10
  A Windows vulnerability allows attackers to spoof valid certificate chains when
  the system root store is in use. These releases include a mitigation for Go
  applications, but it’s strongly recommended that affected users install the
  Windows security update to protect their system.
  This issue is CVE-2020-0601 and Go issue golang.org/issue/36834.
- Panic in crypto/x509 certificate parsing and golang.org/x/crypto/cryptobyte
  On 32-bit architectures, a malformed input to crypto/x509 or the ASN.1 parsing
  functions of golang.org/x/crypto/cryptobyte can lead to a panic.
  The malformed certificate can be delivered via a crypto/tls connection to a
  client, or to a server that accepts client certificates. net/http clients can
  be made to crash by an HTTPS server, while net/http servers that accept client
  certificates will recover the panic and are unaffected.
  Thanks to Project Wycheproof for providing the test cases that led to the
  discovery of this issue. The issue is CVE-2020-7919 and Go issue golang.org/issue/36837.
  This is also fixed in version v0.0.0-20200124225646-8b5121be2f68 of golang.org/x/crypto/cryptobyte.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>