### PR TITLE
release 1.2.13-1

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -1,7 +1,7 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=dc9208a3303feef5b3839f4323d9beb36df0a9dd
-GOVERSION?=1.12.16
+GOVERSION?=1.12.17
 GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)
 BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+containerd.io (1.2.13-1) release; urgency=medium
+
+  * Update to containerd 1.2.13, which fixes a regression introduced in v1.2.12
+    that caused container/shim to hang on single core machines, and fixes an issue
+    with blkio.
+  * Update Golang runtime to 1.12.17.
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>
+
 containerd.io (1.2.12-1) release; urgency=medium
 
   * Update the runc vendor to v1.0.0-rc10 which includes a mitigation for

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -154,6 +154,12 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Mon Feb 17 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.13-3.1
+- Update to containerd 1.2.13, which fixes a regression introduced in v1.2.12
+  that caused container/shim to hang on single core machines, and fixes an issue
+  with blkio.
+- Update Golang runtime to 1.12.17.
+
 * Tue Feb 04 2020 Derek McGowan <derek@docker.com> - 1.2.12-3.1
 - Update the runc vendor to v1.0.0-rc10 which includes a mitigation for
   CVE-2019-19921.


### PR DESCRIPTION
Opening as draft, pending https://github.com/containerd/containerd/pull/4033 and linked PR's to be merged, and released.