### PR TITLE
[draft] release 1.2.14-1

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -15,7 +15,7 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=dc9208a3303feef5b3839f4323d9beb36df0a9dd
-GOVERSION?=1.12.17
+GOVERSION?=1.13.8
 GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)
 BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD)
 

--- a/debian/changelog.bak
+++ b/debian/changelog.bak
@@ -1,54 +1,13 @@
-containerd.io (1.2.14-1) release; urgency=medium
-
-  * Update to containerd 1.2.14.
-  * Update Golang runtime to 1.13.8.
-
- -- Sebastiaan van Stijn <thajeztah@docker.com>
-
-containerd.io (1.2.13-1) release; urgency=medium
-
-  * Update to containerd 1.2.13, which fixes a regression introduced in v1.2.12
-    that caused container/shim to hang on single core machines, and fixes an issue
-    with blkio.
-  * Update Golang runtime to 1.12.17.
-
- -- Sebastiaan van Stijn <thajeztah@docker.com>
-
-containerd.io (1.2.12-1) release; urgency=medium
-
-  * Update the runc vendor to v1.0.0-rc10 which includes a mitigation for
-    CVE-2019-19921.
-  * Update the opencontainers/selinux which includes a mitigation for
-    CVE-2019-16884.
-  * Update Golang runtime to 1.12.16, mitigating the CVE-2020-0601
-    certificate verification bypass on Windows, and CVE-2020-7919,
-    which only affects 32-bit architectures.
-  * A fix to prevent SIGSEGV when starting containerd-shim
-  * Fix to prevent high system load/CPU utilization with liveness and readiness
-    probes
-  * Fix to prevent docker exec hanging if an earlier docker exec left a zombie
-    process
-  * CRI: Update the gopkg.in/yaml.v2 vendor to v2.2.8 with a mitigation for
-    CVE-2019-11253
-
- -- Derek McGowan <derek@docker.com>  Tue, 04 Feb 2020 9:43:30 +0000
-
-containerd.io (1.2.11-2) release; urgency=medium
-
-  * Update Golang runtime to 1.12.15, which includes fixes in the net/http package
-    and the runtime on ARM64
-
- -- Sebastiaan van Stijn <thajeztah@docker.com>
-
 containerd.io (1.2.11-1) release; urgency=medium
 
   * Update the runc vendor to v1.0.0-rc9 which includes an additional
     mitigation for CVE-2019-16884
   * Add local-fs.target to service file to fix corrupt image after unexpected
     host reboot
-  * Update Golang runtime to 1.12.13, which includes security fixes to the
-    crypto/dsa package made in Go 1.12.11 (CVE-2019-17596), and fixes to the
-    go command, runtime, syscall and net packages (Go 1.12.12)
+  * Update Golang runtime to 1.12.15, which includes security fixes to the
+    crypto/dsa package made in Go 1.12.11 (CVE-2019-17596), fixes to the go
+    command, runtime, syscall and net packages (Go 1.12.12), and fixes in the
+    net/http package and the runtime on ARM64 (Go 1.12.15)
   * CRI: Fix shim delete error code to avoid unnecessary retries in the CRI plugin
 
  -- Evan Hazlett <evan@docker.com>  Thu, 9 Jan 2020 20:40:43 +0000

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -154,6 +154,10 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 
 
 %changelog
+* Fri Feb 28 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.14-3.1
+- Update to containerd 1.2.14.
+- Update Golang runtime to 1.13.8.
+
 * Mon Feb 17 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.13-3.1
 - Update to containerd 1.2.13, which fixes a regression introduced in v1.2.12
   that caused container/shim to hang on single core machines, and fixes an issue


### PR DESCRIPTION
- Update to containerd 1.2.14.
- Update Golang runtime to 1.13.8.
