### PR TITLE
Jenkinsfile: add Ubuntu 20.04 "focal"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ def images = [
     [image: "ubuntu:bionic",                  arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
     [image: "ubuntu:disco",                   arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 19.03  (EOL: January, 2020)
     [image: "ubuntu:eoan",                    arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 19.10  (EOL: July, 2020)
+    [image: "ubuntu:focal",                   arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
 ]
 
 def generatePackageStep(opts, arch) {


### PR DESCRIPTION
Hi folks,

I modeled this Pull Request off of #117 (https://github.com/docker/containerd-packaging/pull/117/commits/c941ec34626c8a1b9bdc8570facb5af660ec2efc).

See also https://github.com/docker/docker-ce-packaging/pull/443. This present PR, together with that PR I just mentioned, should address https://github.com/docker/for-linux/issues/940 for Ubuntu Focal.

Please note that I signed off my commit with a pseudonym (my GitHub username), so this probably shouldn't actually be merged. Just a proof-of-concept implementation.

I aim to demonstrate this can be done, discover and troubleshoot any bugs that arise, and generally bring preparedness up so Docker can transition easily into packaging for Ubuntu 20.04 Focal Fossa, which comes out in a little over a month.

Best Regards.