### PR TITLE
Force header check to run on amd64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
     agent none
     stages {
         stage('Check file headers') {
-            agent any
+            agent { label 'linux&&amd64' }
             steps{
                 script{
                     checkout scm


### PR DESCRIPTION
Jenkins now has s390x machines enabled, which don't currently
have a CentOS 7 image on Docker Hub, causing the check to fail.
