### PR TITLE
Fix date in changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -81,7 +81,7 @@ containerd.io (1.2.8-1) release; urgency=medium
   * containerd 1.2.8 release
   * build with Go 1.12.9
 
- -- Sebastiaan van Stijn <thajeztah@docker.com>  Mon, 27 Aug 2019 22:40:56 +0000
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Tue, 27 Aug 2019 22:40:56 +0000
 
 containerd.io (1.2.6-4) release; urgency=high
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -202,7 +202,7 @@ install -p -m 644 man/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 - containerd 1.2.9 release
 - Addresses CVE-2019-9512 (Ping Flood), CVE-2019-9514 (Reset Flood), and CVE-2019-9515 (Settings Flood).
 
-* Mon Aug 27 2019 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.8-3.1
+* Tue Aug 27 2019 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.8-3.1
 - containerd 1.2.8 release
 - build with Go 1.12.9
 


### PR DESCRIPTION
It was a Tuesday, not a Monday 😓

    warning: bogus date in %changelog: Mon Aug 27 2019 Sebastiaan van Stijn <thajeztah@docker.com> - 1.2.8-3.1
