### PR TITLE
rpm: add support for building on CentOS 8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@
 def images = [
     [image: "amazonlinux:2",                  arches: ["aarch64"]],
     [image: "centos:7",                       arches: ["amd64", "aarch64", "armhf"]],
+    [image: "centos:8",                       arches: ["amd64", "aarch64"]],          // Note: armhf (arm32) images are currently not available on Docker Hub
     [image: "debian:stretch",                 arches: ["amd64", "aarch64", "armhf"]], // Debian 9  (EOL: June, 2022)
     [image: "debian:buster",                  arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
     [image: "fedora:29",                      arches: ["amd64", "aarch64"]],

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -45,6 +45,7 @@ FROM redhat-base AS rhel-base
 ENV BUILDTAGS=no_btrfs
 
 FROM redhat-base AS centos-base
+RUN if [ -f /etc/yum.repos.d/CentOS-PowerTools.repo ]; then sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-PowerTools.repo; fi
 
 FROM redhat-base AS amzn-base
 

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -45,8 +45,6 @@ FROM redhat-base AS rhel-base
 ENV BUILDTAGS=no_btrfs
 
 FROM redhat-base AS centos-base
-# Overwrite repo that was failing on aarch64
-RUN sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo
 
 FROM redhat-base AS amzn-base
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -99,7 +99,12 @@ cd %{_topdir}/BUILD
 make man
 
 pushd /go/src/%{import_path}
-%define make_containerd(o:) make VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} %{?**};
+BUILDTAGS="seccomp selinux"
+%if 1%{!?el8:1}
+BUILDTAGS="${BUILDTAGS} no_btrfs"
+%endif
+
+%define make_containerd(o:) make VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} GO_BUILDTAGS="${BUILDTAGS}" %{?**};
 %make_containerd bin/containerd
 /go/src/%{import_path}/bin/containerd --version
 %make_containerd bin/containerd-shim


### PR DESCRIPTION
replaces https://github.com/docker/containerd-packaging/pull/118