### PR TITLE
deb: use non-interactive, and no-install-recommends

### DIFF
--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -42,7 +42,14 @@ RUN cat /etc/os-release
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install some pre-reqs
-RUN apt-get update && apt-get install -y --no-install-recommends curl devscripts equivs git lsb-release
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    devscripts \
+    equivs \
+    git \
+    lsb-release \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /go
 ENV GOPATH=/go
@@ -56,7 +63,10 @@ COPY debian/ /root/containerd/debian/
 WORKDIR /root/containerd
 
 # Install all of our build dependencies, if any
-RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i debian/control
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i debian/control \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Copy over our entrypoint
 COPY scripts/build-deb /build-deb

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -39,9 +39,10 @@ RUN go get github.com/cpuguy83/go-md2man/v2/@${MD2MAN_VERSION}
 
 FROM ${BUILD_IMAGE}
 RUN cat /etc/os-release
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install some pre-reqs
-RUN apt-get update && apt-get install -y curl devscripts equivs git lsb-release
+RUN apt-get update && apt-get install -y --no-install-recommends curl devscripts equivs git lsb-release
 
 RUN mkdir -p /go
 ENV GOPATH=/go


### PR DESCRIPTION
The devscripts package on newer Ubuntu/Debian versions adds a HUGE
amount of new dependencies. Unfortunately we need this package as
it's the only package that provides `mk-build-deps`, but we don't
have to install all recommended packages:

On Ubuntu 20.04, without `--no-install-recommends`:

    4 upgraded, 334 newly installed, 0 to remove and 4 not upgraded.
    Need to get 100 MB of archives.
    After this operation, 445 MB of additional disk space will be used.

And with `--no-install-recommends`;

    0 upgraded, 104 newly installed, 0 to remove and 8 not upgraded.
    Need to get 25.0 MB of archives.
    After this operation, 119 MB of additional disk space will be used.

This patch also sets `DEBIAN_FRONTEND=noninteractive`, to prevent build
hanging if a package (such as `tzdata`) waits for user input otherwise.


The second commit updates handling of apt package cache; This patch removes the apt-cache after installing packages, and refreshes (`apt-get update`) before installing dependencies using `mk-build-deps` to prevent using a possibly stale index when dependencies in the control file change.

 

