### PR TITLE
[WIP] Use EC2 agents for armhf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,11 @@ def images = [
 
 def generatePackageStep(opts, arch) {
     return {
-        node("linux&&${arch}") {
+        def nodeLabel = "linux&&${arch}"
+        if (arch == "armhf") {
+            nodeLabel = "ubuntu-1804-overlay2-arm32v7"
+        }
+        node(nodeLabel) {
             stage("${opts.image}-${arch}") {
                 try {
                     sh 'docker version'


### PR DESCRIPTION
Use AWS EC2 instances for armhf builds instead of baremetal pet machines.
