### PR TITLE
rpm: add libseccomp to "requires"

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -42,7 +42,6 @@ FROM ${BUILD_IMAGE} AS redhat-base
 RUN yum install -y yum-utils rpm-build git
 
 FROM redhat-base AS rhel-base
-ENV BUILDTAGS=no_btrfs
 
 FROM redhat-base AS centos-base
 RUN if [ -f /etc/yum.repos.d/CentOS-PowerTools.repo ]; then sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-PowerTools.repo; fi

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -58,6 +58,7 @@ Source3: runc
 %if "%{?dist}" != ".amzn2"
 Requires: container-selinux >= 2:2.74
 %endif
+Requires: libseccomp
 %endif
 BuildRequires: make
 BuildRequires: gcc


### PR DESCRIPTION
extracting this from https://github.com/docker/containerd-packaging/pull/154


this fixes installation on CentOS 8