### PR TITLE
rpm: fix Oracle Linux 8 build

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -50,7 +50,8 @@ RUN if [ -f /etc/yum.repos.d/CentOS-PowerTools.repo ]; then sed -i 's/enabled=0/
 FROM redhat-base AS amzn-base
 
 FROM redhat-base AS ol-base
-ENV EXTRA_REPOS="--enablerepo=ol7_optional_latest"
+RUN . "/etc/os-release"; if [ "${VERSION_ID%.*}" -eq 7 ]; then yum-config-manager --enable ol7_addons --enable ol7_optional_latest; fi
+RUN . "/etc/os-release"; if [ "${VERSION_ID%.*}" -eq 8 ]; then yum-config-manager --enable ol8_addons; fi
 
 FROM ${BUILD_IMAGE} AS fedora-base
 RUN dnf install -y rpm-build git dnf-plugins-core


### PR DESCRIPTION
extracting this from https://github.com/docker/containerd-packaging/pull/154


the extra repo was set unconditionally, which caused
Oracle Linux 8 builds to fail, because it doesn't have
that repo.
