### PR TITLE
CentOS: fix failing repository on aarch64 (arm64)

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -46,6 +46,9 @@ ENV BUILDTAGS=no_btrfs
 
 FROM redhat-base AS centos-base
 RUN if [ -f /etc/yum.repos.d/CentOS-PowerTools.repo ]; then sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-PowerTools.repo; fi
+# In aarch64 (arm64) images, the altarch repo is specified as repository, but
+# failing, so replace the URL.
+RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo; fi
 
 FROM redhat-base AS amzn-base
 


### PR DESCRIPTION
extracting this from https://github.com/docker/containerd-packaging/pull/154


This repository is only specified in the aarch64 (arm64) images,
and therefore was not caught in CI.

Bringing back the fix that was previously there, to prevent failures:

    #20 0.800 + yum-builddep -y SPECS/containerd.spec
    #20 1.135 Loaded plugins: fastestmirror, ovl
    #20 1.365 Enabling base-source repository
    #20 1.366 Enabling extras-source repository
    #20 1.366 Enabling updates-source repository
    #20 1.368 Loading mirror speeds from cached hostfile
    #20 1.370  * base: d36uatko69830t.cloudfront.net
    #20 1.371  * extras: d36uatko69830t.cloudfront.net
    #20 1.371  * updates: d36uatko69830t.cloudfront.net
    #20 3.063 http://vault.centos.org/altarch/7/extras/Source/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
    #20 3.075 Trying other mirror.
    #20 3.075 To address this issue please refer to the below wiki article

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>