### PR TITLE
Makefile: don't detect BUILD_BASE, BUILD_TYPE unless needed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,6 @@ def generatePackageStep(opts, arch) {
                     sh '''
                     curl -fsSL "https://raw.githubusercontent.com/moby/moby/master/contrib/check-config.sh" | bash || true
                     '''
-                    sh("docker pull ${opts.image}")
                     checkout scm
                     sh("make BUILD_IMAGE=${opts.image} CREATE_ARCHIVE=1 clean build")
                     archiveArtifacts(artifacts: 'archive/*.tar.gz', onlyIfSuccessful: true)

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,6 @@ BUILD_IMAGE=centos:7
 BUILD_TYPE=$(shell ./scripts/deb-or-rpm $(BUILD_IMAGE))
 BUILD_BASE=$(shell ./scripts/determine-base $(BUILD_IMAGE))
 
-ifeq ($(BUILD_BASE),)
-$(error Invalid build image $(BUILD_IMAGE) no build base found)
-endif
-
-ifeq ($(BUILD_TYPE),)
-$(error Invalid build image $(BUILD_IMAGE) no build type found)
-endif
-
 BUILD?=DOCKER_BUILDKIT=1 docker build \
 	$(BUILD_ARGS) \
 	-f dockerfiles/$(BUILD_TYPE).dockerfile \
@@ -61,6 +53,11 @@ clean:
 
 .PHONY: build
 build:
+	@docker pull "$(BUILD_IMAGE)"
+
+	@if [ -z "$(BUILD_BASE)" ]; then echo "Invalid build image $(BUILD_IMAGE) no build base found"; exit 1; fi
+	@if [ -z "$(BUILD_TYPE)" ]; then echo "Invalid build image $(BUILD_IMAGE) no build type found"; exit 1; fi
+
 	$(BUILD)
 	$(RUN)
 	$(CHOWN_TO_USER) build/
@@ -68,4 +65,3 @@ build:
 .PHONY: validate
 validate: ## Validate files license header
 	docker run --rm -v $(CURDIR):/work -w /work $(GOLANG_IMAGE) bash -c 'go get -u github.com/kunalkushwaha/ltag && ./scripts/validate/fileheader'
-


### PR DESCRIPTION
extracting this from https://github.com/docker/containerd-packaging/pull/154


Detecting BUILD_BASE and BUILD_TYPE involves pulling an image
from Docker Hub and running it, which is not needed for all
targets.

This patch moves these steps to where it's actually needed.

