### PR TITLE
Makefile: remove "PACKAGE" variable

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -20,7 +20,6 @@ GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)
 BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD)
 
 ARCH:=$(shell uname -m)
-PACKAGE?=containerd.io
 
 BUILD_ARGS=--build-arg REF="$(REF)" \
 	--build-arg GOLANG_IMAGE="$(GOLANG_IMAGE)" \


### PR DESCRIPTION
extracting this from https://github.com/docker/containerd-packaging/pull/154

A default is already defined in the Dockerfile, and it was not passed as build-arg, so unused.
