### PR TITLE
Makefile: follow upstream Go version by default

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -15,8 +15,14 @@
 GOARCH=$(shell docker run --rm golang go env GOARCH 2>/dev/null)
 REF?=$(shell git ls-remote https://github.com/containerd/containerd.git | grep master | awk '{print $$1}')
 RUNC_REF?=dc9208a3303feef5b3839f4323d9beb36df0a9dd
-GOVERSION?=1.12.17
-GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)
+
+ifdef CONTAINERD_DIR
+GOVERSION?=$(shell grep "ARG GOLANG_VERSION" $(CONTAINERD_DIR)/contrib/Dockerfile.test | awk -F'=' '{print $$2}')
+else
+GOVERSION?=$(shell curl -fsSL "https://raw.githubusercontent.com/containerd/containerd/$(REF)/contrib/Dockerfile.test" | grep "ARG GOLANG_VERSION" | awk -F'=' '{print $$2}')
+endif
+
+GOLANG_IMAGE=golang:$(GOVERSION)
 BUILDER_IMAGE=containerd-builder-$@-$(GOARCH):$(shell git rev-parse --short HEAD)
 
 ARCH:=$(shell uname -m)

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -14,7 +14,7 @@
 
 ARG BUILD_IMAGE=ubuntu:bionic
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
-ARG GOLANG_IMAGE
+ARG GOLANG_IMAGE=golang:latest
 
 FROM ${GOLANG_IMAGE} AS golang
 

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -15,7 +15,7 @@
 ARG BUILD_IMAGE=centos:7
 ARG BASE=centos
 # Install golang since the package managed one probably is too old and ppa's don't cover all distros
-ARG GOLANG_IMAGE
+ARG GOLANG_IMAGE=golang:latest
 
 FROM ${GOLANG_IMAGE} AS golang
 


### PR DESCRIPTION
The master branch requires Go 1.13 or up, but other branches may still expect an older version of Go.

This patch makes the Go version used default to the version that's used in upstream, but allows overriding the version by manually setting the `GOVERSION` make variable.

Also setting a default value for the golang image in the Dockerfiles (defaulting to `golang:latest`)