### PR TITLE
Remove Ubuntu Disco

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ def images = [
     [image: "balenalib/rpi-raspbian:buster",  arches: ["armhf"]],
     [image: "ubuntu:xenial",                  arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 16.04 LTS (End of support: April, 2021. EOL: April, 2024)
     [image: "ubuntu:bionic",                  arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
-    [image: "ubuntu:disco",                   arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 19.03  (EOL: January, 2020)
     [image: "ubuntu:eoan",                    arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 19.10  (EOL: July, 2020)
     [image: "ubuntu:focal",                   arches: ["amd64", "aarch64", "s390x"]],          // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
 ]


### PR DESCRIPTION
Ubuntu Disco has reached EOL in January 2020, currently the CI builds are failing.
This PR removes the distro again.
🕺