### PR TITLE
Makefile: allow overriding repository to build from

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ src/github.com/containerd/containerd:
 	cp -r "$(CONTAINERD_DIR)" $@
 else
 src/github.com/containerd/containerd:
-	git clone https://github.com/containerd/containerd.git $@
+	git clone "$(CONTAINERD_REMOTE)" $@
 endif
 
 # This targets allows building multiple distros at once, for example:

--- a/Makefile.win
+++ b/Makefile.win
@@ -14,8 +14,6 @@
 
 include common/common.mk
 
-CONTAINERD_MOUNT:=C:/gopath/src/github.com/containerd/containerd
-
 src: src/github.com/containerd/containerd
 
 ifdef CONTAINERD_DIR
@@ -44,8 +42,8 @@ build/windows/%.exe: windows-image checkout
 	docker run \
 		--rm \
 		-v "$(CURDIR)/src/:C:/gopath/src" \
-		-v "$(CURDIR)/build/windows:$(CONTAINERD_MOUNT)/bin" \
-		-w "$(CONTAINERD_MOUNT)" \
+		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
+		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
 		make bin/$*
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -21,7 +21,7 @@ src/github.com/containerd/containerd:
 	Xcopy /E /I "$(CONTAINERD_DIR)" $@
 else
 src/github.com/containerd/containerd:
-	git clone https://github.com/containerd/containerd.git $@
+	git clone "$(CONTAINERD_REMOTE)" $@
 endif
 
 .PHONY: checkout

--- a/common/common.mk
+++ b/common/common.mk
@@ -12,12 +12,16 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+# NOTE: When overriding CONTAINERD_REMOTE, make sure to also specify
+#       GOVERSION, as it's hardcoded to look in the upstream repository
+CONTAINERD_REMOTE?=https://github.com/containerd/containerd.git
 REF?=HEAD
 RUNC_REF?=dc9208a3303feef5b3839f4323d9beb36df0a9dd
 
 ifdef CONTAINERD_DIR
 GOVERSION?=$(shell grep "ARG GOLANG_VERSION" $(CONTAINERD_DIR)/contrib/Dockerfile.test | awk -F'=' '{print $$2}')
 else
+# TODO adjust GOVERSION macro to take CONTAINERD_REMOTE into account
 GOVERSION?=$(shell curl -fsSL "https://raw.githubusercontent.com/containerd/containerd/$(REF)/contrib/Dockerfile.test" | grep "ARG GOLANG_VERSION" | awk -F'=' '{print $$2}')
 endif
 


### PR DESCRIPTION
Our internal pipeline has a configuration to override the repository to build from. While it's not currently used, there could be situations where it's usefull (e.g. when building an embargoed security release).

This patch adds a CONTAINERD_REMOTE makefile variable that allows overriding the repository that we fetch the source from.

Also cleaning up the `CONTAINERD_MOUNT` variable, as it didn't serve any use