### PR TITLE
Makefile: use shallow clone, and add RUNC_REMOTE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ clean:
 	-$(RM) -r artifacts
 	-$(RM) -r src
 
+.PHONY: src
 src: src/github.com/opencontainers/runc src/github.com/containerd/containerd
 
 ifdef RUNC_DIR
@@ -41,7 +42,7 @@ src/github.com/opencontainers/runc:
 	cp -r "$(RUNC_DIR)" $@
 else
 src/github.com/opencontainers/runc:
-	git clone https://github.com/opencontainers/runc.git $@
+	git clone "$(RUNC_REMOTE)" $@
 endif
 
 ifdef CONTAINERD_DIR

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ src/github.com/opencontainers/runc:
 	cp -r "$(RUNC_DIR)" $@
 else
 src/github.com/opencontainers/runc:
-	git clone "$(RUNC_REMOTE)" $@
+	git init $@
+	git -C $@ remote add origin "$(RUNC_REMOTE)"
 endif
 
 ifdef CONTAINERD_DIR
@@ -51,7 +52,8 @@ src/github.com/containerd/containerd:
 	cp -r "$(CONTAINERD_DIR)" $@
 else
 src/github.com/containerd/containerd:
-	git clone "$(CONTAINERD_REMOTE)" $@
+	git init $@
+	git -C $@ remote add origin "$(CONTAINERD_REMOTE)"
 endif
 
 # This targets allows building multiple distros at once, for example:
@@ -65,8 +67,10 @@ docker.io/%:
 
 .PHONY: checkout
 checkout: src
-	@git -C src/github.com/opencontainers/runc   checkout -q "$(RUNC_REF)"
-	@git -C src/github.com/containerd/containerd checkout -q "$(REF)"
+	@git -C src/github.com/opencontainers/runc fetch --depth 1 origin "$(RUNC_REF)"
+	@git -C src/github.com/opencontainers/runc checkout -q FETCH_HEAD
+	@git -C src/github.com/containerd/containerd fetch --depth 1 origin "$(REF)"
+	@git -C src/github.com/containerd/containerd checkout -q FETCH_HEAD
 
 .PHONY: build
 build: checkout

--- a/Makefile.win
+++ b/Makefile.win
@@ -14,6 +14,7 @@
 
 include common/common.mk
 
+.PHONY: src
 src: src/github.com/containerd/containerd
 
 ifdef CONTAINERD_DIR

--- a/Makefile.win
+++ b/Makefile.win
@@ -22,12 +22,14 @@ src/github.com/containerd/containerd:
 	Xcopy /E /I "$(CONTAINERD_DIR)" $@
 else
 src/github.com/containerd/containerd:
-	git clone "$(CONTAINERD_REMOTE)" $@
+	git init $@
+	git -C $@ remote add origin "$(CONTAINERD_REMOTE)"
 endif
 
 .PHONY: checkout
 checkout: src
-	@git -C src/github.com/containerd/containerd checkout -q "$(REF)"
+	@git -C src/github.com/containerd/containerd fetch --depth 1 origin "$(REF)"
+	@git -C src/github.com/containerd/containerd checkout -q FETCH_HEAD
 
 # Windows builder, only difference is we installed make
 windows-image:

--- a/common/common.mk
+++ b/common/common.mk
@@ -14,7 +14,8 @@
 
 # NOTE: When overriding CONTAINERD_REMOTE, make sure to also specify
 #       GOVERSION, as it's hardcoded to look in the upstream repository
-CONTAINERD_REMOTE?=https://github.com/containerd/containerd.git
+CONTAINERD_REMOTE ?=https://github.com/containerd/containerd.git
+RUNC_REMOTE       ?=https://github.com/opencontainers/runc.git
 REF?=HEAD
 RUNC_REF?=dc9208a3303feef5b3839f4323d9beb36df0a9dd
 


### PR DESCRIPTION
### Makefile: add RUNC_REMOTE parameter, and make src a "phony"

This made the makefile slightly cleaner, and could be useful to build from a fork (just as we added for containerd itself)

### Makefile: use shallow clone to speed up fetching source

Before:

    time make REF=v1.3.4 checkout
    ...
    Resolving deltas: 100% (30812/30812), done.
           19.37 real         2.70 user         3.11 sys


After:

    time make REF=v1.3.4 checkout
    ...
    Resolving deltas: 100% (659/659), done.
    From https://github.com/containerd/containerd
     * tag               v1.3.4     -> FETCH_HEAD
            7.95 real         0.57 user         1.12 sys