### PR TITLE
Makefile.win: pull image when building

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -34,6 +34,7 @@ checkout: src
 # Windows builder, only difference is we installed make
 windows-image:
 	docker build \
+		--pull \
 		--build-arg GOLANG_IMAGE=$(GOLANG_IMAGE) \
 		-t dockereng/containerd-windows-builder \
 		-f dockerfiles/win.dockerfile \


### PR DESCRIPTION
Prevent stale images in the local image cache when building

This change was already made on the linux side, but looks like I forgot to stage this change for windows