### PR TITLE
Remove "CREATE_ARCHIVE"; archive .deb/.rpm's artifacts directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-archive/
 artifacts/
 build/
 common/containerd.service

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,9 +37,9 @@ def generatePackageStep(opts, arch) {
                     checkout scm
                     sh 'make clean'
                     withDockerRegistry([url: "", credentialsId: "dockerbuildbot-index.docker.io"]) {
-                        sh "make CREATE_ARCHIVE=1 ${opts.image}"
+                        sh "make ${opts.image}"
                     }
-                    archiveArtifacts(artifacts: 'archive/*.tar.gz', onlyIfSuccessful: true)
+                    archiveArtifacts(artifacts: 'build/**/containerd.io*.*', onlyIfSuccessful: true)
                 } finally {
                     deleteDir()
                 }

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,6 @@ build:
 		--build-arg GOLANG_IMAGE="$(GOLANG_IMAGE)" \
 		--build-arg BUILD_IMAGE="$(BUILD_IMAGE)" \
 		--build-arg BASE="$(BUILD_BASE)" \
-		--build-arg CREATE_ARCHIVE="$(CREATE_ARCHIVE)" \
 		--build-arg UID="$(shell id -u)" \
 		--build-arg GID="$(shell id -g)" \
 		--file="dockerfiles/$(BUILD_TYPE).dockerfile" \

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -98,7 +98,6 @@ ENV PACKAGE=${PACKAGE:-containerd.io}
 FROM build-env AS build-packages
 RUN mkdir -p /archive /build
 COPY common/containerd.service common/containerd.toml /root/common/
-ARG CREATE_ARCHIVE
 # NOTE: not using a cache-mount for /root/.cache/go-build, to prevent issues
 #       with CGO when building multiple distros on the same machine / build-cache
 RUN --mount=type=bind,from=golang,source=/usr/local/go/,target=/usr/local/go/ \

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -81,7 +81,6 @@ ENV PACKAGE=${PACKAGE:-containerd.io}
 FROM build-env AS build-packages
 RUN mkdir -p /archive /build
 COPY common/containerd.service common/containerd.toml SOURCES/
-ARG CREATE_ARCHIVE
 # NOTE: not using a cache-mount for /root/.cache/go-build, to prevent issues
 #       with CGO when building multiple distros on the same machine / build-cache
 RUN --mount=type=bind,from=golang,source=/usr/local/go/,target=/usr/local/go/ \

--- a/scripts/build-deb
+++ b/scripts/build-deb
@@ -62,8 +62,3 @@ if [ "${DIST_VERSION}" = 'n/a' ]; then
 	echo "Failed to get release codename"
 	exit 1
 fi
-
-# Only create an archive if env variable is specified
-if [ -n "${CREATE_ARCHIVE}" ]; then
-	tar -C /build -cvzf "/archive/${DIST_ID}-${DIST_VERSION}-${ARCH}.tar.gz" "${DIST_ID}/${DIST_VERSION}/${ARCH}"
-fi

--- a/scripts/build-rpm
+++ b/scripts/build-rpm
@@ -74,8 +74,3 @@ DEST_DIR="/build/${DIST_ID}/${DIST_VERSION}/${ARCH}/"
 	mv -v RPMS/*/*.rpm "${DEST_DIR}"
 	mv -v SRPMS/*.rpm "${DEST_DIR}"
 )
-
-# Only create an archive if env variable is specified
-if [ -n "${CREATE_ARCHIVE}" ]; then
-	tar -C /build -cvzf "/archive/${DIST_ID}-${DIST_VERSION}-${ARCH}.tar.gz" "${DIST_ID}/${DIST_VERSION}/${ARCH}"
-fi


### PR DESCRIPTION
deb and rpm packages are already compressed, so compressing them again does not save any space.

This patch removes the "CREATE_ARCHIVE" option, and instead just the deb/rpm's itself as artifacts

### Before this

Tars are uploaded as artefact in Jenkins:

<img width="1184" alt="Screenshot 2021-11-22 at 11 48 17" src="https://user-images.githubusercontent.com/1804568/142849013-b0a1f831-01f3-46fb-a569-eae68e0a1d64.png">


### After this

The individual `.deb` and `.rpm` packages are uploaded as artefact:

<img width="1184" alt="Screenshot 2021-11-23 at 13 05 24" src="https://user-images.githubusercontent.com/1804568/143021200-57804f99-713f-48be-bddb-4920602e6088.png">

