### PR TITLE
rpm: containerd 1.2 compatible BUILDTAGS variable

### DIFF
--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -109,7 +109,7 @@ BUILDTAGS="seccomp selinux"
 BUILDTAGS="${BUILDTAGS} no_btrfs"
 %endif
 
-make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} GO_BUILDTAGS="${BUILDTAGS}"
+make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} BUILDTAGS="${BUILDTAGS}"
 
 # Remove containerd-stress, as we're not shipping it as part of the packages
 rm -f bin/containerd-stress


### PR DESCRIPTION
Starting from containerd 1.3, the BUILDTAGS variable is renamed to GO_BUILDTAGS.
Since we still need to release containerd 1.2, this patch reverts to BUILDTAGS.

When switching to containerd 1.3, this patch can be reverted.

Signed-off-by: Tibor Vass <tibor@docker.com>

cc @thaJeztah 