### PR TITLE
Add checkout.sh to handle tags with shallow clones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,8 @@ docker.io/%:
 
 .PHONY: checkout
 checkout: src
-	@git -C src/github.com/opencontainers/runc fetch --depth 1 origin "$(RUNC_REF)"
-	@git -C src/github.com/opencontainers/runc checkout -q FETCH_HEAD
-	@git -C src/github.com/containerd/containerd fetch --depth 1 origin "$(REF)"
-	@git -C src/github.com/containerd/containerd checkout -q FETCH_HEAD
+	./scripts/checkout.sh src/github.com/opencontainers/runc "$(RUNC_REF)"
+	./scripts/checkout.sh src/github.com/containerd/containerd "$(REF)"
 
 .PHONY: build
 build: checkout

--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+
+#   Copyright 2018-2020 Docker Inc.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+checkout() (
+	set -ex
+	SRC="$1"
+	REF="$2"
+	REF_FETCH="$REF"
+	# if ref is branch or tag, retrieve its canonical form
+	REF=$(git -C "$SRC" ls-remote --refs --heads --tags origin "$REF" | awk '{print $2}')
+	if [ -n "$REF" ]; then
+		# if branch or tag then create it locally too
+		REF_FETCH="$REF:$REF"
+	else
+		REF="FETCH_HEAD"
+	fi
+	git -C "$SRC" fetch --depth 1 origin "$REF_FETCH"
+	git -C "$SRC" checkout -q "$REF"
+)
+
+
+# Only execute checkout function above if this file is executed, not sourced from another script
+prog=checkout.sh # needs to be in sync with this file's name
+if [ "$(basename -- $0)" = "$prog" ]; then
+	checkout $*
+fi


### PR DESCRIPTION
Commit 9706347c34524feb83d75a7119ea88311b41e668 changed to shallow clones
but fetching a tag ref does not download the tag itself.
This patch makes sure that the tag (or branch) is downloaded otherwise
fallsback to fetching the commit hash as it did before.

Signed-off-by: Tibor Vass <tibor@docker.com>

Ref #173