### PR TITLE
DONOTMERGE: Build armhf on EC2 machines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,18 +10,18 @@ def images = [
     [image: "docker.io/library/centos:7",               arches: ["amd64", "aarch64"]],
     [image: "docker.io/dockereng/rhel:7-s390x",         arches: ["s390x"]],
     [image: "docker.io/library/centos:8",               arches: ["amd64", "aarch64"]],
-    [image: "docker.io/library/debian:stretch",         arches: ["amd64", "aarch64", "armhf"]], // Debian 9  (EOL: June, 2022)
-    [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
+    [image: "docker.io/library/debian:stretch",         arches: ["amd64", "aarch64", "off-armhf"]], // Debian 9  (EOL: June, 2022)
+    [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "off-armhf"]], // Debian 10 (EOL: 2024)
     [image: "docker.io/library/fedora:30",              arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/fedora:31",              arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/fedora:32",              arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/fedora:rawhide",         arches: ["amd64"]],                              // Rawhide is the name given to the current development version of Fedora
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
-    [image: "docker.io/balenalib/rpi-raspbian:stretch", arches: ["armhf"]],
-    [image: "docker.io/balenalib/rpi-raspbian:buster",  arches: ["armhf"]],
-    [image: "docker.io/library/ubuntu:xenial",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 16.04 LTS (End of support: April, 2021. EOL: April, 2024)
-    [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
-    [image: "docker.io/library/ubuntu:eoan",            arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 19.10  (EOL: July, 2020)
+    [image: "docker.io/balenalib/rpi-raspbian:stretch", arches: ["off-armhf"]],
+    [image: "docker.io/balenalib/rpi-raspbian:buster",  arches: ["off-armhf"]],
+    [image: "docker.io/library/ubuntu:xenial",          arches: ["amd64", "aarch64", "off-armhf"]], // Ubuntu 16.04 LTS (End of support: April, 2021. EOL: April, 2024)
+    [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "off-armhf", "s390x"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
+    [image: "docker.io/library/ubuntu:eoan",            arches: ["amd64", "aarch64", "off-armhf"]], // Ubuntu 19.10  (EOL: July, 2020)
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64"]],          // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
 ]
 


### PR DESCRIPTION
Run a build for all armhf packages on new EC2 machines with 32bit docker-ce 19.03.9/containerd.io installed. These machines have a temporary label `off-armhf` right now.

Related to https://github.com/docker/dev-tooling-team/issues/158