### PR TITLE
Jenkinsfile: enable armhf builds for ubuntu:focal and above

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,9 +21,9 @@ def images = [
     [image: "docker.io/balenalib/rpi-raspbian:bullseye",arches: ["armhf"]],
     [image: "docker.io/library/ubuntu:xenial",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 16.04 LTS (End of support: April, 2021. EOL: April, 2024)
     [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
-    [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64"]],          // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
-    [image: "docker.io/library/ubuntu:groovy",          arches: ["amd64", "aarch64"]],          // Ubuntu 20.10 (EOL: July, 2021)
-    [image: "docker.io/library/ubuntu:hirsute",         arches: ["amd64", "aarch64"]],          // Ubuntu 21.04 (EOL: January, 2022)
+    [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
+    [image: "docker.io/library/ubuntu:groovy",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.10 (EOL: July, 2021)
+    [image: "docker.io/library/ubuntu:hirsute",         arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 21.04 (EOL: January, 2022)
 ]
 
 def generatePackageStep(opts, arch) {


### PR DESCRIPTION
Now that our agents run on a more recent kernel version, problems with seccomp should likely be resolved, so we can enable these for CI.

closes https://github.com/docker/containerd-packaging/pull/185
closes https://github.com/docker/containerd-packaging/pull/151
closes https://github.com/docker/containerd-packaging/pull/142

relates to https://github.com/moby/moby/issues/40734