### PR TITLE
Set OOM-score in systemd unit to prevent containerd being OOM-killed

### DIFF
--- a/common/containerd.service
+++ b/common/containerd.service
@@ -29,5 +29,12 @@ LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
 
+# Decreases the likelihood that containerd is killed due to memory pressure.
+#
+# Refer to the following link for more information about the OOMScoreAdjust
+# configuration property:
+# https://www.freedesktop.org/software/systemd/man/systemd.exec.html#OOMScoreAdjust=
+OOMScoreAdjust=-999
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- relates to / addresses https://github.com/docker/for-linux/issues/1062#issuecomment-660916887
- relates to https://github.com/containerd/containerd/pull/4409 Set a default OOM score for containerd
    - sets the default OOM-score for containerd to `-999`

We can remove this option once https://github.com/containerd/containerd/pull/4409 is merged, and once docker switches to containerd 1.4.x (or 1.3.x if that PR is backported)

--------------

If containerd is running as a child-process of dockerd, an OOM-score is set for containerd;

    # Stop the docker and containerd systemd service
    systemctl stop docker
    systemctl stop containerd

    # Manually start dockerd (this will start containerd as a child
    # process if no containerd service is running)
    dockerd &

    # Check the config file that was written;
    cat /var/run/docker/containerd/containerd.toml | grep oom_score
    oom_score = -500

    # And verified that the oom-score is -500;
    cat /proc/$(pidof containerd)/oom_score_adj
    -500

However, if containerd is running as its own service, the default
oom-score is used, which currently is `0` (no adjustment);

    systemctl start docker
    cat /proc/$(pidof containerd)/oom_score_adj
    0

This patch sets the OOM-score for the containerd service to
`-999` ("almost unkillable") to make it less likely for containerd
to be killed by the OOM killer.
