### PR TITLE
scripts/checkout.sh: fix git fetch when explicitly fetching "master"

### DIFF
--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -27,7 +27,7 @@ checkout() (
 	else
 		REF="FETCH_HEAD"
 	fi
-	git -C "$SRC" fetch --depth 1 origin "$REF_FETCH"
+	git -C "$SRC" fetch --update-head-ok --depth 1 origin "$REF_FETCH"
 	git -C "$SRC" checkout -q "$REF"
 )
 


### PR DESCRIPTION
Before:

    git init src/github.com/containerd/containerd
    # Initialized empty Git repository in /root/test/packaging/src/github.com/containerd/containerd/.git/
    git -C src/github.com/containerd/containerd remote add origin "https://github.com/containerd/containerd.git"
    ...
    git -C src/github.com/containerd/containerd fetch --depth 1 origin refs/heads/master:refs/heads/master
    # fatal: Refusing to fetch into current branch refs/heads/master of non-bare repository
    # make[1]: *** [Makefile:72: checkout] Error 128
    # make[1]: Leaving directory '/root/test/packaging'
    # make: *** [Makefile:67: docker.io/library/ubuntu:focal] Error 2
    # make: Leaving directory '/root/test/packaging'

After:

    git init src/github.com/containerd/containerd
    # Initialized empty Git repository in /root/test/packaging/src/github.com/containerd/containerd/.git/
    git -C src/github.com/containerd/containerd remote add origin "https://github.com/containerd/containerd.git"
    ...
    git -C src/github.com/containerd/containerd fetch --update-head-ok --depth 1 origin refs/heads/master:refs/heads/master
    # remote: Enumerating objects: 3869, done.
    # remote: Counting objects: 100% (3869/3869), done.
    # remote: Compressing objects: 100% (3337/3337), done.
    # remote: Total 3869 (delta 695), reused 1605 (delta 272), pack-reused 0
    # Receiving objects: 100% (3869/3869), 6.33 MiB | 9.10 MiB/s, done.
    # Resolving deltas: 100% (695/695), done.
    # From https://github.com/containerd/containerd
    #  * [new branch]      master     -> master
    #  * [new branch]      master     -> origin/master

