### PR TITLE
Makefile: use Ubuntu:20.04 as default BUILD_IMAGE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 include common/common.mk
 
-BUILD_IMAGE=centos:7
+BUILD_IMAGE=ubuntu:focal
 BUILD_TYPE=$(shell ./scripts/deb-or-rpm $(BUILD_IMAGE))
 BUILD_BASE=$(shell ./scripts/determine-base $(BUILD_IMAGE))
 

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG BUILD_IMAGE=ubuntu:bionic
+ARG BUILD_IMAGE=ubuntu:focal
 ARG GOLANG_IMAGE=golang:latest
 
 # Install golang from the official image, since the package managed


### PR DESCRIPTION
I don't think there was a specific reason for picking Centos as the default