### PR TITLE
Jenkinsfile: remove Fedora 30, Ubuntu 19.10 "Eoan", Debian / Raspbian 9 "stretch"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,13 +10,11 @@ def images = [
     [image: "docker.io/library/centos:7",               arches: ["amd64", "aarch64"]],
     [image: "docker.io/dockereng/rhel:7-s390x",         arches: ["s390x"]],
     [image: "docker.io/library/centos:8",               arches: ["amd64", "aarch64"]],
-    [image: "docker.io/library/debian:stretch",         arches: ["amd64", "aarch64", "armhf"]], // Debian 9  (EOL: June, 2022)
     [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
     [image: "docker.io/library/fedora:31",              arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/fedora:32",              arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/fedora:rawhide",         arches: ["amd64"]],                              // Rawhide is the name given to the current development version of Fedora
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
-    [image: "docker.io/balenalib/rpi-raspbian:stretch", arches: ["armhf"]],
     [image: "docker.io/balenalib/rpi-raspbian:buster",  arches: ["armhf"]],
     [image: "docker.io/library/ubuntu:xenial",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 16.04 LTS (End of support: April, 2021. EOL: April, 2024)
     [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ def images = [
     [image: "docker.io/balenalib/rpi-raspbian:buster",  arches: ["armhf"]],
     [image: "docker.io/library/ubuntu:xenial",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 16.04 LTS (End of support: April, 2021. EOL: April, 2024)
     [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
-    [image: "docker.io/library/ubuntu:eoan",            arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 19.10  (EOL: July, 2020)
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64"]],          // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
 ]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,6 @@ def images = [
     [image: "docker.io/library/centos:8",               arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/debian:stretch",         arches: ["amd64", "aarch64", "armhf"]], // Debian 9  (EOL: June, 2022)
     [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
-    [image: "docker.io/library/fedora:30",              arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/fedora:31",              arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/fedora:32",              arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/fedora:rawhide",         arches: ["amd64"]],                              // Rawhide is the name given to the current development version of Fedora


### PR DESCRIPTION
- Fedora 30 reached EOL on 2020-05-26: https://fedoraproject.org/wiki/End_of_life
- Ubuntu 19.10 "Eoan Ermine" reached EOL on 2020-07-17: https://wiki.ubuntu.com/Releases
- Debian GNU/Linux 9 "Stretch" reached EOL on 2020-07-06: https://wiki.debian.org/DebianReleases


Note that this only removes these from the Jenkinsfile; it's still possible to build these, but this PR will remove them from the matrix that's built by default in CI