### PR TITLE
Update systemd unit-file with changes from upstream

### DIFF
--- a/common/containerd.service
+++ b/common/containerd.service
@@ -15,7 +15,7 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network.target
+After=network.target local-fs.target
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay

--- a/common/containerd.service
+++ b/common/containerd.service
@@ -22,6 +22,8 @@ ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd
 KillMode=process
 Delegate=yes
+Restart=always
+RestartSec=5
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.


### PR DESCRIPTION
Includes upstream changes from;

- https://github.com/containerd/containerd/pull/3741 Add local-fs.target to service file
    - fixes https://github.com/containerd/containerd/issues/3671 Unable to recover corrupt image after unexpected host reboot
- https://github.com/containerd/containerd/pull/3297 add Restart=always to unit file
    - also added `RestartSec`, which was added in https://github.com/containerd/containerd/commit/1c7312e5da1ae8ca3cf238397939ed1d24f60758

We should change the packaging to use the upstream systemd unit, but looks like the path used in upstream is `/usr/local/bin/containerd` whereas packaging here uses `/usr/bin/containerd`, so I'll look at that separately.
