### PR TITLE
systemd: Support NOTIFY_SOCKET

### DIFF
--- a/common/containerd.service
+++ b/common/containerd.service
@@ -20,6 +20,8 @@ After=network.target
 [Service]
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd
+
+Type=notify
 KillMode=process
 Delegate=yes
 LimitNOFILE=1048576


### PR DESCRIPTION
matching the changes upstream from;

- https://github.com/containerd/containerd/pull/4088 Support NOTIFY_SOCKET
    - relates to https://github.com/containerd/containerd/issues/4043

Support NOTIFY_SOCKET to support notifying the daemon's readiness to systemd.

Note that this change requires containerd 1.4 or above, as (from the systemd
documentation: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=

> Behavior of notify is similar to exec; however, it is expected that the service sends a
> notification message via sd_notify(3) or an equivalent call when it has finished starting
> up. **systemd will proceed with starting follow-up units after this notification message
> has been sent**. (...)

Which (if I understand correctly) means that if the process does *not* send a notification
message, systemd will not continue starting other services that depend on systemd.

I kept this separate from https://github.com/docker/containerd-packaging/pull/192 because of the above

