### PR TITLE
Change install location from /usr/bin to /usr/local/bin

### DIFF
--- a/common/containerd.service
+++ b/common/containerd.service
@@ -19,7 +19,7 @@ After=network.target
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/bin/containerd
+ExecStart=/usr/local/bin/containerd
 KillMode=process
 Delegate=yes
 LimitNOFILE=1048576

--- a/debian/rules
+++ b/debian/rules
@@ -51,8 +51,10 @@ override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade
 	sed -i 's/_dh_action=try-restart/_dh_action=restart/g' ./debian/containerd.io.postinst.debhelper
 
+override_dh_usrlocal: # Skip processing dh_usrlocal
+
 override_dh_auto_install: binaries bin/runc man
-	mkdir -p debian/containerd.io/usr/bin
-	install -D -m 0755 bin/* debian/containerd.io/usr/bin
+	mkdir -p debian/containerd.io/usr/local/bin
+	install -D -m 0755 bin/* debian/containerd.io/usr/local/bin
 	install -D -m 0644 /root/common/containerd.service debian/containerd.io/lib/systemd/system/containerd.service
 	install -D -m 0644 /root/common/containerd.toml    debian/containerd.io/etc/containerd/config.toml

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -121,8 +121,8 @@ make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin BUILD
 
 %install
 cd %{_topdir}/BUILD
-mkdir -p %{buildroot}%{_bindir}
-install -D -m 0755 bin/* %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_exec_prefix}/local/bin
+install -D -m 0755 bin/* %{buildroot}%{_exec_prefix}/local/bin
 install -D -m 0644 %{S:1} %{buildroot}%{_unitdir}/containerd.service
 install -D -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
 
@@ -149,7 +149,7 @@ done
 %files
 %license LICENSE
 %doc README.md
-%{_bindir}/*
+%{_exec_prefix}/local/bin/*
 %{_unitdir}/containerd.service
 %{_sysconfdir}/containerd
 %{_mandir}/man*/*


### PR DESCRIPTION
This changes the install location of packages from `/usr/bin` to `/usr/local/bin`
to match upstream.

Given that we're building a non-distro package, `/usr/local/bin` looks to be the
correct location; https://unix.stackexchange.com/a/8658

> /usr/bin is for distribution-managed normal user programs.
> /usr/local/bin is for normal user programs not managed by the distribution
> package manager, e.g. locally compiled packages. You should not install them
> into /usr/bin because future distribution upgrades may modify or delete them
> without warning.

The specification does not call out "distro" and "non-distro" packages, but does
explain that `/usr/bin` can be overwritten by system upgrades, and `/usr/local/bin`
should therefore be preferred;

https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s09.html#purpose24

> # 4.9. /usr/local : Local hierarchy
> ## 4.9.1. Purpose
>
> The /usr/local hierarchy is for use by the system administrator when installing
> software locally. It needs to be safe from being overwritten when the system
> software is updated. It may be used for programs and data that are shareable
> amongst a group of hosts, but not found in /usr.
>
> Locally installed software must be placed within /usr/local rather than /usr
> unless it is being installed to replace or upgrade software in /usr.
>
> Software placed in / or /usr may be overwritten by system upgrades (though we
> recommend that distributions do not overwrite data in /etc under these
> circumstances). For this reason, local software must not be placed outside of
> /usr/local without good reason.


After this change, we should also be able to switch to using the upstream systemd unit file
