### PR TITLE
Use 'runc_nokmem' build tag for RHEL/CentOS 7.x RPMs

### DIFF
--- a/scripts/build-rpm
+++ b/scripts/build-rpm
@@ -61,6 +61,12 @@ ARCH="$(uname -m)"
 DEST_DIR="/build/${DIST_ID}/${DIST_VERSION}/${ARCH}/"
 (
 	set -x
+	# Set 'runc_nokmem' build tag for RHEL/CentOS 7.x
+	if [[ "$DIST_ID" == "centos" || "$DIST_ID" == "rhel" ]]; then
+		if [[ "$DIST_VERSION" =~ ^7.* ]]; then
+			export RUNC_NOKMEM="nokmem"
+		fi
+	fi
 	rpmbuild -ba "${SPEC_FILE}"
 	mkdir -p "${DEST_DIR}"
 	mv -v RPMS/*/*.rpm "${DEST_DIR}"


### PR DESCRIPTION
https://github.com/docker/containerd-packaging/pull/66 originally did this, but I think the nokmem-related changes were inadvertently removed when the Makefile changed later on.

This again ensures that the "nokmem" build tag is used for RHEL/CentOS 7.x builds.