### PR TITLE
Jenkinsfile: Add Ubuntu 20.10 "Groovy Gorilla"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ def images = [
     [image: "docker.io/library/ubuntu:xenial",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 16.04 LTS (End of support: April, 2021. EOL: April, 2024)
     [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64"]],          // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
+    [image: "docker.io/library/ubuntu:groovy",          arches: ["amd64", "aarch64"]],          // Ubuntu 20.10 (EOL: July, 2021)
 ]
 
 def generatePackageStep(opts, arch) {


### PR DESCRIPTION
Hi folks,

This is to address the issue I opened, #197.

Ubuntu 20.10 will be out soon (in about "a month plus a week"). This PR adds Ubuntu 20.10 "Groovy Gorilla" to the list of distro releases to build against in the Jenkinsfile.

Consider adding this to be prepared early for the upcoming Ubuntu release. Thanks.