### PR TITLE
[1.3] Jenkinsfile: add Fedora 33 (beta) to CI matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,8 @@ def images = [
     [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
     [image: "docker.io/library/fedora:31",              arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/fedora:32",              arches: ["amd64", "aarch64"]],
-    [image: "docker.io/library/fedora:rawhide",         arches: ["amd64"]],                              // Rawhide is the name given to the current development version of Fedora
+    [image: "docker.io/library/fedora:33",              arches: ["amd64", "aarch64"]],
+    [image: "docker.io/library/fedora:rawhide",         arches: ["amd64"]],                     // Rawhide is the name given to the current development version of Fedora
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
     [image: "docker.io/balenalib/rpi-raspbian:buster",  arches: ["armhf"]],
     [image: "docker.io/library/ubuntu:xenial",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 16.04 LTS (End of support: April, 2021. EOL: April, 2024)


### PR DESCRIPTION
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 23066b954d57ab4b9d4dab78b0941f2346aa2b66)
Signed-off-by: Tibor Vass <tibor@docker.com>