### PR TITLE
release 1.4.3 (CVE-2020-15257)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.4.2-1) release; urgency=medium
+
+  * Update to containerd 1.4.2
+  * Update Golang runtime to 1.15.5
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Thu, 26 Nov 2020 13:34:04 +0000
+
 containerd.io (1.4.1-1) release; urgency=medium
 
   * Update to containerd 1.4.1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,12 @@
+containerd.io (1.4.3-1) release; urgency=high
+
+  * Update to containerd 1.4.3 to address CVE-2020-15257.
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Wed, 02 Dec 2020 14:33:09 +0000
+
 containerd.io (1.4.2-1) release; urgency=medium
 
   * Update to containerd 1.4.2
-  * Update Golang runtime to 1.15.5
 
  -- Sebastiaan van Stijn <thajeztah@docker.com>  Thu, 26 Nov 2020 13:34:04 +0000
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -157,6 +157,10 @@ done
 
 
 %changelog
+* Thu Nov 26 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.2-3.1
+- Update to containerd 1.4.2
+- Update Golang runtime to 1.15.5
+
 * Tue Oct 06 2020 Tibor Vass <tibor@docker.com> - 1.4.1-3.1
 - Update to containerd 1.4.1
 - Update Golang runtime to 1.13.15

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -157,9 +157,11 @@ done
 
 
 %changelog
+* Wed Dec 02 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.3-3.1
+- Update to containerd 1.4.3 to address CVE-2020-15257.
+
 * Thu Nov 26 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.2-3.1
 - Update to containerd 1.4.2
-- Update Golang runtime to 1.15.5
 
 * Tue Oct 06 2020 Tibor Vass <tibor@docker.com> - 1.4.1-3.1
 - Update to containerd 1.4.1


### PR DESCRIPTION
release 1.4.3 (CVE-2020-15257)
----------------------------------------

upstream release notes:

Welcome to the v1.4.3 release of containerd!

The third patch release for containerd 1.4 is a security release to
address CVE-2020-15257. See GHSA-36xw-fx78-c5r4 for more details:

https://github.com/containerd/containerd/security/advisories/GHSA-36xw-fx78-c5r4

release 1.4.2
----------------------------------------

- Update to containerd 1.4.2
- Update Golang runtime to 1.15.5

Upstream containerd 1.4.2 release notes: https://github.com/containerd/containerd/releases/tag/v1.4.2

Welcome to the v1.4.2 release of containerd!
------------------------------------------------------

The second patch release for containerd 1.4 includes multiple minor fixes
and updates.

Notable Updates

- Fix bug limiting the number of layers by default containerd/cri#1602
- Fix selinux shared memory issue by relabeling /dev/shm containerd/cri#1605
- Fix unknown state preventing removal of containers containerd/containerd#4656
- Fix nil pointer error when restoring checkpoint containerd/containerd#4754
- Improve image pull performance when using HTTP 1.1 containerd/containerd#4653
- Update default seccomp profile for pidfd containerd/containerd#4730
- Update Go to 1.15

Windows

- Fix integer overflow on Windows containerd/containerd#4589
- Fix lcow snapshotter to read trailing tar data containerd/containerd#4628

