### PR TITLE
Jenkinsfile: use "wrappedNode" to set Docker Hub creds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ def images = [
 
 def generatePackageStep(opts, arch) {
     return {
-        node("linux&&${arch}") {
+        wrappedNode(label: "linux&&${arch}") {
             stage("${opts.image}-${arch}") {
                 try {
                     sh 'docker version'


### PR DESCRIPTION
The "dockereng/rhel" repository is private, so make sure credentials are set.
