### PR TITLE
release 1.3.9 (fix CVE-2020-15257)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.3.9-1) release; urgency=high
+
+  * Update to containerd 1.3.9 to address CVE-2020-15257
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Mon, 30 Nov 2020 18:53:07 +0000
+
 containerd.io (1.3.8-1) release; urgency=medium
 
   * Update to containerd 1.3.8

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.3.8-1) release; urgency=medium
+
+  * Update to containerd 1.3.8
+  * Update Golang runtime to 1.13.15
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Mon, 30 Nov 2020 17:04:17 +0000
+
 containerd.io (1.3.7-1) release; urgency=medium
 
   * Update to containerd 1.3.7

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -157,6 +157,10 @@ done
 
 
 %changelog
+* Mon Nov 30 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.3.8-3.1
+- Update to containerd 1.3.8
+- Update Golang runtime to 1.13.15
+
 * Wed Sep 09 2020 Sebastiaan van Stijn <github@gone.nl> - 1.3.7-3.1
 - Update to containerd 1.3.7
 - Update Golang runtime to 1.13.12.

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -157,6 +157,9 @@ done
 
 
 %changelog
+* Mon Nov 30 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.3.9-3.1
+- Update to containerd 1.3.9 to address CVE-2020-15257
+
 * Mon Nov 30 2020 Sebastiaan van Stijn <thajeztah@docker.com> - 1.3.8-3.1
 - Update to containerd 1.3.8
 - Update Golang runtime to 1.13.15


### PR DESCRIPTION
### release 1.3.9 (fix CVE-2020-15257)

upstream release notes:

    Welcome to the v1.3.9 release of containerd!

    The ninth patch release for containerd 1.3 is a security release to address CVE-2020-15257.
    See GHSA-36xw-fx78-c5r4 for more details:
    https://github.com/containerd/containerd/security/advisories/GHSA-36xw-fx78-c5r4

### release 1.3.8

upstream release notes (https://github.com/containerd/containerd/releases/tag/v1.3.8):

- Fix metrics monitoring of v2 runtime tasks
- Fix nil pointer error when restoring checkpoint
- Fix devmapper device deletion on rollback
- Fix integer overflow on Windows
- Update seccomp default profile
