### PR TITLE
Makefile: switch to POSIX mode to handle errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+.POSIX:
+
 include common/common.mk
 
 BUILD_IMAGE=centos:7


### PR DESCRIPTION
similar to https://github.com/docker/docker-ce-packaging/pull/510 and https://github.com/moby/sys/pull/19#discussion_r445698069

relates to https://github.com/docker/docker-ce-packaging/pull/504#issuecomment-737078670

> .POSIX
>
> The application shall ensure that this special target is specified without prerequisites
> or commands. If it appears as the first non-comment line in the makefile, make shall
> process the makefile as specified by this section; otherwise, the behavior of make is
> unspecified.

Running the makefile with `.POSIX` runs shells with the `-e` options, which helps with
handling errors; without this, make can complet "succesfully", even if shell commands
in a target fail.

Note that this patch does not change behavior on macOS, which runs an older version of
GNU make that does not support these options.
