### PR TITLE
Force Go to 1.13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ def generatePackageStep(opts, arch) {
                     checkout scm
                     sh 'make clean'
                     withDockerRegistry([url: "", credentialsId: "dockerbuildbot-index.docker.io"]) {
-                        sh "make CREATE_ARCHIVE=1 ${opts.image}"
+                        sh "make GO_VERSION=1.13.15 CREATE_ARCHIVE=1 ${opts.image}"
                     }
                     archiveArtifacts(artifacts: 'archive/*.tar.gz', onlyIfSuccessful: true)
                 } finally {
@@ -59,7 +59,7 @@ def packageBuildSteps = [
             stage("windows") {
                 try {
                     checkout scm
-                    sh("make -f Makefile.win archive")
+                    sh("make -f Makefile.win GO_VERSION=1.13.15 archive")
                 } finally {
                     deleteDir()
                 }
@@ -78,7 +78,7 @@ pipeline {
             steps{
                 script{
                     checkout scm
-                    sh "make validate"
+                    sh "make GO_VERSION=1.13.15 validate"
                 }
             }
         }


### PR DESCRIPTION
Since Go 1.14, runtime changes make it possible for syscall functions
to return EINTR errors. We are not aware of an analysis of such callers.

As this could impact users badly and in obscure ways this patch ensures
containerd and runc binaries are built with Go 1.13 for now.

Signed-off-by: Tibor Vass <tibor@docker.com>