### PR TITLE
deb: make dh-systemd dependency optional as it's deprecated

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Containerd team <help@containerd.io>
 Build-Depends: libbtrfs-dev | btrfs-tools ,
-               debhelper,
-               dh-systemd,
+               debhelper (>= 10~) | dh-systemd,
                pkg-config,
                libseccomp-dev
 Standards-Version: 4.1.4


### PR DESCRIPTION
equivalent of https://github.com/docker/docker-ce-packaging/pull/520 for containerd packaging

dh-systemd has been integrated into debhelper, starting with version 9.20160709,
and has been removed in Debian 11 "bullseye"

This patch updates the control file to not require it as a dependency
on current versions of debian that ship with that version of debhelper

Related discussions:

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=822670
[2] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=958585
