### PR TITLE
Makefile: fix double "-f" on remove

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: build
 .PHONY: clean
 clean:
 	-$(RM) -r build/
-	-$(RM) -f common/containerd.service
+	-$(RM) common/containerd.service
 	-$(RM) -r artifacts
 	-$(RM) -r src
 	-docker builder prune -f --filter until=24h


### PR DESCRIPTION
noticed this when running `make clean`:

    $ make clean
    rm -f -r build/
    rm -f -f common/containerd.service
    rm -f -r artifacts
    rm -f -r src
    docker builder prune -f --filter until=24h
    ...

Looks like `$(RM)` already does `-f`, so adding it here was redundant.
