### PR TITLE
deb: remove redundant " --with systemd" from debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -25,7 +25,7 @@ ifeq ($(DEB_TARGET_ARCH),armhf)
 endif
 
 %:
-	dh $@ --with systemd
+	dh $@
 
 # GO_SRC_PATH and PACKAGE are defined in the dockerfile
 # VERSION and REF are defined in scripts/build-deb


### PR DESCRIPTION
follow-up to https://github.com/docker/containerd-packaging/pull/212. I noticed that we had the `--with systemd` option here as well (see https://github.com/docker/docker-ce-packaging/pull/520#discussion_r555901971)