### PR TITLE
deb: use "containerd.io" as workdir to suppress some warnings

### DIFF
--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -37,7 +37,7 @@ ENV PATH="${PATH}:/usr/local/go/bin:${GOPATH}/bin"
 ENV IMPORT_PATH=github.com/containerd/containerd
 ENV GO_SRC_PATH="/go/src/${IMPORT_PATH}"
 ARG DEBIAN_FRONTEND=noninteractive
-WORKDIR /root/containerd
+WORKDIR /root/containerd.io
 
 # Install some pre-reqs
 # NOTE: not using a cache-mount for apt, to prevent issues when building multiple


### PR DESCRIPTION
dpkg-source expects the directory to match the package name (containerd.io)

    dpkg-source: warning: source directory 'containerd' is not <sourcepackage>-<upstreamversion> 'containerd.io-0.20210219.014044~e58be59'
