### PR TITLE
deb: keep '/var/lib/apt/lists/' to allow building for Debian unstable

### DIFF
--- a/scripts/build-deb
+++ b/scripts/build-deb
@@ -55,6 +55,14 @@ DEST_DIR="/build/${DIST_ID}/${DIST_VERSION}/${ARCH}/"
 mkdir -p "${DEST_DIR}"
 mv -v ../*.deb "${DEST_DIR}"
 
+if [ "${DIST_VERSION}" = 'n/a' ]; then
+	# Give a more useful error message if we failed to get the "codename",
+	# which can be the case on Debian "unstable" releases. For more background:
+	# https://github.com/docker/containerd-packaging/pull/213#issuecomment-782172567
+	echo "Failed to get release codename"
+	exit 1
+fi
+
 # Only create an archive if env variable is specified
 if [ -n "${CREATE_ARCHIVE}" ]; then
 	tar -C /build -cvzf "/archive/${DIST_ID}-${DIST_VERSION}-${ARCH}.tar.gz" "${DIST_ID}/${DIST_VERSION}/${ARCH}"


### PR DESCRIPTION
relates to https://github.com/docker/containerd-packaging/pull/213#issuecomment-782172567

Debian "unstable" releases use apt caching information to get the codename
see discussion on https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845651:

> That's all to say that this bug is (to my belief) actually expected behaviour;
> and fixing it through forcing the codename to be interpreted as "stretch" when
> apt-cache information is unavailable would be wrong. When /etc/debian_version
> contains "potato/sid", the codename is either potato xor sid, and only apt-
> cache can discriminate a testing host from a sid host. Therefore, in such a
> situation, the correct answer is actually "I can't tell", aka "n/a".

From testing, it reads the information from these files:

  - /var/lib/apt/lists/deb.debian.org_debian_dists_bullseye_InRelease
  - /var/lib/apt/lists/deb.debian.org_debian_dists_bullseye_main_binary-amd64_Packages.lz4

Removing these files (`rm -rf /var/lib/apt/lists/*`) causes 'lsb_release -sc`
to print 'n/a'. While we could use '/etc/debian_version' as a fallback for our
own scripts (stripping everything after '/' (e.g. bullseye/sid -> bullseye),
dpkg-buildpackage will still depend on this information to be present, and
if not present, renames packages to use 'n/a' in their path:

    dpkg-buildpackage: info: full upload; Debian-native package (full source is included)
    renamed '../containerd.io-dbgsym_0.20210219.014044~e58be59-1_amd64.deb' -> '/build/debian/n/a/amd64/containerd.io-dbgsym_0.20210219.014044~e58be59-1_amd64.deb'
    renamed '../containerd.io_0.20210219.014044~e58be59-1_amd64.deb' -> '/build/debian/n/a/amd64/containerd.io_0.20210219.014044~e58be59-1_amd64.deb'

Given that we don't need the final image (as we only use it as a build environment
and copy the artifacts out), keeping some of the cache files should not be a problem.
