### PR TITLE
Jenkins parameters belong to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,17 @@
 #!groovy
 
+properties(
+    [
+        parameters(
+            [
+                booleanParam(name: 'ARCHIVE', defaultValue: false, description: 'Archive the build artifacts by pushing to an S3 bucket.'),
+                string(name: 'CONTAINERD_REF', defaultValue: 'master', description: 'Git ref of containerd repo to build.'),
+                string(name: 'RUNC_REF', defaultValue: '', description: 'Git ref of runc repo to build.'),
+            ]
+        )
+    ]
+)
+
 // List of packages to build. Note that this list is overridden in the packaging
 // repository, where additional variants may be added for enterprise.
 //


### PR DESCRIPTION
For some unknown reasons there are Jenkins parameters that are neither defined in Jenkins nor in Jenkinsfile.

ARCHIVE and CONTAINERD_REF were taken from the output of:
https://ci-next.docker.com/teams-core/job/containerd-packaging/job/master/configure

while RUNC_REF was added so we can build a version different from the vendored one in containerd.

Signed-off-by: Tibor Vass <tibor@docker.com>