### PR TITLE
Fix detection of default runc version due upstream to switch to go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean:
 	-docker builder prune -f --filter until=24h
 
 .PHONY: src
-src: src/github.com/opencontainers/runc src/github.com/containerd/containerd
+src: src/github.com/containerd/containerd src/github.com/opencontainers/runc
 
 common/containerd.service: checkout
 	# upstream systemd unit uses /usr/local/bin, whereas our packages use /usr/bin
@@ -73,8 +73,8 @@ docker.io/%:
 
 .PHONY: checkout
 checkout: src
-	./scripts/checkout.sh src/github.com/opencontainers/runc "$(RUNC_REF)"
 	./scripts/checkout.sh src/github.com/containerd/containerd "$(REF)"
+	./scripts/checkout.sh src/github.com/opencontainers/runc "$(RUNC_REF)"
 
 .PHONY: build
 build: checkout common/containerd.service
@@ -110,4 +110,4 @@ build:
 
 .PHONY: validate
 validate: ## Validate files license header
-	docker run --rm -v $(CURDIR):/work -w /work $(GOLANG_IMAGE) bash -c 'go get -u github.com/kunalkushwaha/ltag && ./scripts/validate/fileheader'
+	docker run --rm -v $(CURDIR):/work -w /work golang:alpine sh -c 'go install github.com/kunalkushwaha/ltag@latest && ./scripts/validate/fileheader'

--- a/Makefile.win
+++ b/Makefile.win
@@ -32,7 +32,7 @@ checkout: src
 	@git -C src/github.com/containerd/containerd checkout -q FETCH_HEAD
 
 # Windows builder, only difference is we installed make
-windows-image:
+windows-image: checkout
 	docker build \
 		--pull \
 		--build-arg GOLANG_IMAGE=$(GOLANG_IMAGE) \
@@ -41,7 +41,7 @@ windows-image:
 		.
 	echo 1 > $@
 
-build/windows/%.exe: windows-image checkout
+build/windows/%.exe: windows-image
 	Powershell.exe New-Item -ItemType Directory -Force -Path build/windows/
 	docker run \
 		--rm \

--- a/common/common.mk
+++ b/common/common.mk
@@ -19,17 +19,8 @@ RUNC_REMOTE       ?=https://github.com/opencontainers/runc.git
 REF?=HEAD
 
 # Select the default version of Golang and runc based on the containerd source.
-# The runc version commit/tag is defined in vendor.conf. Code below is based on
-# the code used in the containerd repository:
-# https://github.com/containerd/containerd/blob/499fbb0337c9138b5360117e0b25a7a1428f9667/script/setup/install-runc#L24
-ifdef CONTAINERD_DIR
-GOVERSION?=$(shell grep "ARG GOLANG_VERSION" $(CONTAINERD_DIR)/contrib/Dockerfile.test | awk -F'=' '{print $$2}')
-RUNC_REF?=$(shell grep "opencontainers/runc" "$(CONTAINERD_DIR)/vendor.conf" | awk '{print $$2}')
-else
-# TODO adjust GOVERSION and RUNC_REF macro to take CONTAINERD_REMOTE into account
-GOVERSION?=$(shell curl -fsSL "https://raw.githubusercontent.com/containerd/containerd/$(REF)/contrib/Dockerfile.test" | grep "ARG GOLANG_VERSION" | awk -F'=' '{print $$2}')
-RUNC_REF?=$(shell curl -fsSL "https://raw.githubusercontent.com/containerd/containerd/$(REF)/vendor.conf" | grep "opencontainers/runc" | awk '{print $$2}')
-endif
+GOVERSION?=$(shell grep "ARG GOLANG_VERSION" src/github.com/containerd/containerd/contrib/Dockerfile.test | awk -F'=' '{print $$2}')
+RUNC_REF?=$(shell scripts/determine-runc-version)
 
 GOLANG_IMAGE=golang:$(GOVERSION)
 ifeq ($(OS),Windows_NT)

--- a/scripts/determine-runc-version
+++ b/scripts/determine-runc-version
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+
+#   Copyright 2018-2020 Docker Inc.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Select the default version of runc based on the containerd source if no
+# RUNC_REF is set manually. For containerd > 1.5.0-beta.4, and containerd > 1.4.4,
+# the runc version commit/tag is defined script/setup/runc-version. For older
+# versions, use go.mod or vendor.conf.
+#
+# See the install-runc script in the containerd repository:
+# https://github.com/containerd/containerd/blob/v1.5.0-beta.4/script/setup/install-runc#L24-L27
+# https://github.com/containerd/containerd/blob/v1.5.0-beta.3/script/setup/install-runc#L24
+# https://github.com/containerd/containerd/blob/v1.4.0/script/setup/install-runc#L24
+runc_version() {
+	if [ -n "${RUNC_REF}" ]; then
+		# just a safe-guard if this script is called when RUNC_REF was already set.
+		echo "${RUNC_REF}"
+		>&2 echo "INFO: using runc version from RUNC_REF."
+		return
+	fi
+
+	# shellcheck disable=SC2164
+	repo_abspath="$(cd -- "$(dirname -- "$0")/.." > /dev/null 2>&1; pwd -P)"
+	containerd_src_dir="${repo_abspath}/src/github.com/containerd/containerd"
+
+	if [ -f "${containerd_src_dir}/script/setup/runc-version" ]; then
+		# containerd v1.5.0-beta.4 and up, and v1.4.5 and up specify the version of
+		# runc to use in script/setup/runc-version.
+		cat "${containerd_src_dir}/script/setup/runc-version"
+		>&2 echo "INFO: detected runc version from script/setup/runc-version"
+		return
+	elif [ -f "${containerd_src_dir}/go.mod" ]; then
+		# containerd master between v1.4.x and v1.5.0-beta.4 required the runc binary
+		# to be the same version as the vendored (libcontainer) dependency, specified
+		# in go.mod. containerd v1.5.0-beta.4 (and up), and v1.4.5 (and up) decoupled
+		# the binary version from the libnetwork version, and use script/setup/runc-version
+		grep 'opencontainers/runc' "${containerd_src_dir}/go.mod" | awk '{print $2}'
+		>&2 echo "INFO: detected runc version from go.mod"
+		return
+	elif [ -f "${containerd_src_dir}/vendor.conf" ]; then
+		# containerd master between v1.4.x and v1.5.0-beta.4 required the runc binary
+		# to be the same version as the vendored (libcontainer) dependency, specified
+		# in vendor.conf.
+		grep 'opencontainers/runc' "${containerd_src_dir}/vendor.conf" | awk '{print $2}'
+		>&2 echo "INFO: detected runc version from vendor.conf"
+		return
+	fi
+
+	# if all else fails
+	>&2 echo "INFO: unable to detect runc version, using HEAD"
+	echo "HEAD"
+}
+
+runc_version


### PR DESCRIPTION
The code that was used to automatically select the default version of runc to use for containerd was still assuming the containerd code to have a vendor.conf.

Containerd "master", and v1.5 have switched to go modules, so should now look in the go.mod file to get the recommended / default version.

Also change the order in which we check out source-code, so that the containerd source-code is checked out before we determine the runc version; this allows us to always use the local source of containerd, without having to use curl to get the version from GitHub.

Finally, a small modification was made for the "make validate" target, which now uses a generic "alpine" Golang image, so that validation can be done before the containerd source code was checked out (which was used to detect the Go version to use).

Before this patch:

    $ make docker.io/library/ubuntu:focal
    ...
    curl: (22) The requested URL returned error: 404 Not Found
    --------------------------------------------------------------------
    Building packages on docker.io/library/ubuntu:focal

    containerd   : HEAD (commit: a72fe7d)
    runc         :  (commit: 59ad417)
    architecture : x86_64
    build image  : docker.io/library/ubuntu:focal
    golang image : docker.io/library/golang:1.15.8-buster

With this patch:

    $ make docker.io/library/ubuntu:focal
    ...
    Building packages on docker.io/library/ubuntu:focal

    containerd   : HEAD (commit: a72fe7d)
    runc         : v1.0.0-rc93 (commit: 59ad417)
    architecture : x86_64
    build image  : docker.io/library/ubuntu:focal
    golang image : docker.io/library/golang:1.15.8-buster

