### PR TITLE
Disable go modules (GO111MODULE=off) to force using vendor directory on Go 1.16

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@
 # GO_SRC_PATH and PACKAGE are defined in the dockerfile
 # VERSION and REF are defined in scripts/build-deb
 binaries: ## Create containerd binaries
-	@set -x; make -C $(GO_SRC_PATH) --no-print-directory \
+	@set -x; GO111MODULE=off make -C $(GO_SRC_PATH) --no-print-directory \
 		DESTDIR="$$(pwd)" \
 		VERSION=$${VERSION} \
 		REVISION=$${REF} \
@@ -31,14 +31,13 @@ binaries: ## Create containerd binaries
 	rm -f bin/containerd-stress
 
 bin/runc:
-	@set -x; make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
+	@set -x; GO111MODULE=off make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
 		BINDIR="$$(pwd)/bin" \
 		BUILDTAGS='seccomp apparmor selinux' \
 		runc install
 
 man: ## Create containerd man pages
-	@echo "+ make -C $(GO_SRC_PATH) --no-print-directory man"
-	@make -C $(GO_SRC_PATH) --no-print-directory man
+	@set -x; GO111MODULE=off make -C $(GO_SRC_PATH) --no-print-directory man
 
 	# copy the generated man pages instead of using "make install-man" to allow
 	# dh_installman doing its magic

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -102,21 +102,21 @@ cd %{_topdir}/BUILD/
 
 %build
 cd %{_topdir}/BUILD
-make man
+GO111MODULE=off make man
 
 BUILDTAGS="seccomp selinux"
 %if 1%{!?el8:1}
 BUILDTAGS="${BUILDTAGS} no_btrfs"
 %endif
 
-make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} BUILDTAGS="${BUILDTAGS}"
+GO111MODULE=off make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} BUILDTAGS="${BUILDTAGS}"
 
 # Remove containerd-stress, as we're not shipping it as part of the packages
 rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
 
-make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin BUILDTAGS='seccomp apparmor selinux %{runc_nokmem}' runc install
+GO111MODULE=off make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin BUILDTAGS='seccomp apparmor selinux %{runc_nokmem}' runc install
 
 
 %install


### PR DESCRIPTION
(relates to https://github.com/docker/containerd-packaging/pull/225 - when go modules were used, `go get` / `go build` started failing when attempting to download modules)

Go 1.16 more aggressively forces use of go modules, and as a result for some
steps will ignore the vendor directory, causing the build to fail:

    make REF=v1.4.2 RUNC_REF=59ad417c14143ae6b34e9cf88cf3f6e9c6d5f9e8 GOVERSION=1.16.0 docker.io/library/ubuntu:bionic

    #21 1.417 make[1]: Entering directory '/root/containerd'
    #21 1.418 + pwd
    #21 1.418 + make -C /go/src/github.com/containerd/containerd --no-print-directory DESTDIR=/root/containerd VERSION=1.4.2 REVISION=b321d358e6eef9c82fa3f3bb8826dca3724c58c6 PACKAGE=containerd.io binaries install
    #21 1.579 + bin/ctr
    #21 1.587 go: cannot find main module, but found vendor.conf in /go/src/github.com/containerd/containerd
    #21 1.587 	to create a module there, run:
    #21 1.587 	go mod init
    #21 1.589 Makefile:193: recipe for target 'bin/ctr' failed
    #21 1.589 make[2]: *** [bin/ctr] Error 1
    #21 1.590 make[1]: *** [binaries] Error 2
    #21 1.590 debian/rules:23: recipe for target 'binaries' failed
    #21 1.590 make[1]: Leaving directory '/root/containerd'
    #21 1.596 debian/rules:18: recipe for target 'build' failed
    #21 1.596 make: *** [build] Error 2
    #21 1.596 dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
    ------
    executor failed running [/bin/sh -c /root/build-deb]: exit code: 2
    make[1]: *** [build] Error 1
    make: *** [docker.io/library/ubuntu:bionic] Error 2

    make REF=v1.4.2 RUNC_REF=59ad417c14143ae6b34e9cf88cf3f6e9c6d5f9e8 GOVERSION=1.16.0 docker.io/library/centos:7

    ...
    #23 3.267 + make man
    #23 5.145 + man/ctr.8
    #23 5.146 go run cmd/gen-manpages/main.go ctr.8 man
    #23 5.366 cmd/gen-manpages/main.go:27:2: no required module provides package github.com/containerd/containerd/cmd/containerd/command: working directory is not part of a module
    #23 5.366 cmd/gen-manpages/main.go:28:2: no required module provides package github.com/containerd/containerd/cmd/ctr/app: working directory is not part of a module
    #23 5.366 cmd/gen-manpages/main.go:29:2: no required module provides package github.com/urfave/cli: working directory is not part of a module
    #23 5.368 make: *** [man/ctr.8] Error 1
    #23 5.369
    #23 5.369
    #23 5.369 RPM build errors:
    #23 5.369 error: Bad exit status from /var/tmp/rpm-tmp.XNaFt7 (%build)
    #23 5.369     Bad exit status from /var/tmp/rpm-tmp.XNaFt7 (%build)
    ------
    executor failed running [/bin/sh -c /root/build-rpm]: exit code: 1
    make[1]: *** [build] Error 1
    make: *** [docker.io/library/centos:7] Error 2

