### PR TITLE
Revert "Jenkins parameters belong to Jenkinsfile"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,17 +1,5 @@
 #!groovy
 
-properties(
-    [
-        parameters(
-            [
-                booleanParam(name: 'ARCHIVE', defaultValue: false, description: 'Archive the build artifacts by pushing to an S3 bucket.'),
-                string(name: 'CONTAINERD_REF', defaultValue: 'master', description: 'Git ref of containerd repo to build.'),
-                string(name: 'RUNC_REF', defaultValue: '', description: 'Git ref of runc repo to build.'),
-            ]
-        )
-    ]
-)
-
 // List of packages to build. Note that this list is overridden in the packaging
 // repository, where additional variants may be added for enterprise.
 //


### PR DESCRIPTION
This reverts commit 8c249eac8b8c9098ae42d1a6d828c1d8912cb702 (https://github.com/docker/containerd-packaging/pull/222).

These parameters are only used in the release pipeline, which has its own Jenkinsfile, and are not used as part of CI in this repository, so there should be no need to have them in the Jenkinsfile.
