### PR TITLE
prepare release v1.4.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.4.5-1) release; urgency=medium
+
+  * Update to containerd 1.4.5
+  * Update runc to v1.0.0-rc94
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Wed, 12 May 2021 08:29:50 +0000
+
 containerd.io (1.4.4-1) release; urgency=high
 
   * Update to containerd 1.4.4 to address CVE-2021-21334.

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -153,6 +153,10 @@ done
 
 
 %changelog
+* Wed May 12 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.5-3.1
+- Update to containerd 1.4.5
+- Update runc to v1.0.0-rc94
+
 * Mon Mar 08 2021 Wei Fu <fuweid89@gmail.com> - 1.4.4-3.1
 - Update to containerd 1.4.4 to address CVE-2021-21334.
 


### PR DESCRIPTION
depends on https://github.com/docker/containerd-packaging/pull/233


containerd diff: https://github.com/containerd/containerd/compare/v1.4.4...v1.4.5
runc diff: https://github.com/opencontainers/runc/compare/v1.0.0-rc93...v1.0.0-rc94

containerd release notes: https://github.com/containerd/containerd/releases/tag/v1.4.5

- Update runc to rc94
- Fix leaking socket path in runc shim v2
- Fix cleanup logic in new container in runc shim v2
- Fix registry mirror authorization logic in CRI plugin
- Add support for userxattr in overlay snapshotter for kernel 5.11+

runc release notes: https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc94

Potentially breaking changes:

- cgroupv1: kernel memory limits are now always ignored, as kmemcg has
  been effectively deprecated by the kernel. Users should make use of
  regular memory cgroup controls.
- libcontainer/cgroups: cgroup managers' Set now accept
  configs.Resources rather than configs.Cgroups
- libcontainer/cgroups/systemd: reconnect and retry in case dbus
  connection is closed (after dbus restart)
- libcontainer/cgroups/systemd: don't set limits in Apply

Bugfixes:

- seccomp: fix 32-bit compilation errors (regression in rc93)
- cgroupv2: blkio weight value conversion fix
- runc init: fix a hang caused by deadlock in seccomp/ebpf loading code (regression in rc93)
- runc start: fix "chdir to cwd: permission denied" for some setups (regression in rc93)
- s390: fix broken terminal (regression in rc93)

Improvements:

- runc start/exec: better diagnostics when container limits are too low
- runc start/exec: better cleanup after failed runc init
- cgroupv1: improve freezing chances
- cgroupv2: multiple GetStats improvements
- cgroupv2: fallback to setting io.weight if io.bfq.weight is not available
- capabilities: WARN, not ERROR, for unknown / unavailable capabilities
