### PR TITLE
Revert "remove default "containerd.toml" config file"

### DIFF
--- a/common/containerd.toml
+++ b/common/containerd.toml
@@ -1,0 +1,31 @@
+#   Copyright 2018-2020 Docker Inc.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+disabled_plugins = ["cri"]
+
+#root = "/var/lib/containerd"
+#state = "/run/containerd"
+#subreaper = true
+#oom_score = 0
+
+#[grpc]
+#  address = "/run/containerd/containerd.sock"
+#  uid = 0
+#  gid = 0
+
+#[debug]
+#  address = "/run/containerd/debug.sock"
+#  uid = 0
+#  gid = 0
+#  level = "info"

--- a/debian/rules
+++ b/debian/rules
@@ -54,3 +54,4 @@ override_dh_auto_install: binaries bin/runc man
 	mkdir -p debian/containerd.io/usr/bin
 	install -D -m 0755 bin/* debian/containerd.io/usr/bin
 	install -D -m 0644 /root/common/containerd.service debian/containerd.io/lib/systemd/system/containerd.service
+	install -D -m 0644 /root/common/containerd.toml    debian/containerd.io/etc/containerd/config.toml

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -97,7 +97,7 @@ ENV PACKAGE=${PACKAGE:-containerd.io}
 
 FROM build-env AS build-packages
 RUN mkdir -p /archive /build
-COPY common/containerd.service /root/common/
+COPY common/containerd.service common/containerd.toml /root/common/
 ARG CREATE_ARCHIVE
 # NOTE: not using a cache-mount for /root/.cache/go-build, to prevent issues
 #       with CGO when building multiple distros on the same machine / build-cache
@@ -131,4 +131,4 @@ COPY --from=verify-packages /build   /build
 # This stage is mainly for debugging (running the build interactively with mounted source)
 FROM build-env AS runtime
 COPY --from=golang /usr/local/go/ /usr/local/go/
-COPY common/containerd.service /root/common/
+COPY common/containerd.service common/containerd.toml /root/common/

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -79,7 +79,7 @@ ENV PACKAGE=${PACKAGE:-containerd.io}
 
 FROM build-env AS build-packages
 RUN mkdir -p /archive /build
-COPY common/containerd.service SOURCES/
+COPY common/containerd.service common/containerd.toml SOURCES/
 ARG CREATE_ARCHIVE
 # NOTE: not using a cache-mount for /root/.cache/go-build, to prevent issues
 #       with CGO when building multiple distros on the same machine / build-cache
@@ -124,4 +124,4 @@ COPY --from=verify-packages /build   /build
 # This stage is mainly for debugging (running the build interactively with mounted source)
 FROM build-env AS runtime
 COPY --from=golang /usr/local/go/ /usr/local/go/
-COPY common/containerd.service SOURCES/
+COPY common/containerd.service common/containerd.toml SOURCES/

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -50,7 +50,8 @@ License: ASL 2.0
 URL: https://containerd.io
 Source0: containerd
 Source1: containerd.service
-Source2: runc
+Source2: containerd.toml
+Source3: runc
 # container-selinux isn't a thing in suse flavors
 %if %{undefined suse_version}
 # amazonlinux2 doesn't have container-selinux either
@@ -123,6 +124,7 @@ cd %{_topdir}/BUILD
 mkdir -p %{buildroot}%{_bindir}
 install -D -m 0755 bin/* %{buildroot}%{_bindir}
 install -D -m 0644 %{S:1} %{buildroot}%{_unitdir}/containerd.service
+install -D -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
 
 # install manpages, taking into account that not all sections may be present
 for i in $(seq 1 8); do
@@ -149,7 +151,9 @@ done
 %doc README.md
 %{_bindir}/*
 %{_unitdir}/containerd.service
+%{_sysconfdir}/containerd
 %{_mandir}/man*/*
+%config(noreplace) %{_sysconfdir}/containerd/config.toml
 
 
 %changelog


### PR DESCRIPTION
This reverts commit 37e406ca6302b373b5840b794cf551110ad4d737.

Relates to https://github.com/docker/containerd-packaging/pull/215#discussion_r632804641

> removing this does have some impact on rpm users who are currently overwriting
> the rpm supplied config.toml with their own. This being removed above, causes
> the user supplied override config.toml file also to be deleted, when they upgrade
> to a rpm version with this change. rpm moves the file to.rpmsave/.rpmnew after
> upgrading to the new version with the above change.

Reverting this change (at least temporarily until we figure out an alternative)
is the safest option for now.
