### PR TITLE
prepare release v1.4.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.4.6-1) release; urgency=high
+
+  * Update to containerd 1.4.6
+  * Update runc to v1.0.0-rc95 to address CVE-2021-30465.
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Fri, 21 May 2021 07:30:42 +0000
+
 containerd.io (1.4.5-1) release; urgency=medium
 
   * Update to containerd 1.4.5

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -157,6 +157,10 @@ done
 
 
 %changelog
+* Fri May 21 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.6-3.1
+- Update to containerd 1.4.6
+- Update runc to v1.0.0-rc95 to address CVE-2021-30465.
+
 * Wed May 12 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.5-3.1
 - Update to containerd 1.4.5
 - Update runc to v1.0.0-rc94


### PR DESCRIPTION
follow-up to https://github.com/docker/containerd-packaging/pull/232

- Update to containerd 1.4.6
- Update runc to v1.0.0-rc95

containerd diff: https://github.com/containerd/containerd/compare/v1.4.5...v1.4.6
runc diff: https://github.com/opencontainers/runc/compare/v1.0.0-rc94...v1.0.0-rc95

containerd release notes: https://github.com/containerd/containerd/releases/tag/v1.4.6

The sixth patch release for containerd 1.4 is a security release to update
runc for CVE-2021-30465

runc release notes: https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc95

This release of runc contains a fix for CVE-2021-30465, and users are
strongly recommended to update (especially if you are providing
semi-limited access to spawn containers to untrusted users).

Aside from this security fix, only a few other changes were made since
v1.0.0-rc94 (the only user-visible change was the addition of support
for defaultErrnoRet in seccomp profiles).
