### PR TITLE
Fix RUNC_REF not being evaluated correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,15 @@ docker.io/%:
 	$(MAKE) BUILD_IMAGE="$@" build
 
 .PHONY: checkout
-checkout: src
+checkout: checkout-containerd checkout-runc
+
+.PHONY: checkout-containerd
+checkout-containerd: src
 	./scripts/checkout.sh src/github.com/containerd/containerd "$(REF)"
+
+# this must be a separate target, otherwise "RUNC_REF" is not evaluated correctly
+.PHONY: checkout-runc
+checkout-runc: checkout-containerd
 	./scripts/checkout.sh src/github.com/opencontainers/runc "$(RUNC_REF)"
 
 .PHONY: build

--- a/common/common.mk
+++ b/common/common.mk
@@ -20,7 +20,6 @@ REF?=HEAD
 
 # Select the default version of Golang and runc based on the containerd source.
 GOVERSION?=$(shell grep "ARG GOLANG_VERSION" src/github.com/containerd/containerd/contrib/Dockerfile.test | awk -F'=' '{print $$2}')
-RUNC_REF?=$(shell scripts/determine-runc-version)
 
 GOLANG_IMAGE=golang:$(GOVERSION)
 ifeq ($(OS),Windows_NT)

--- a/scripts/determine-runc-version
+++ b/scripts/determine-runc-version
@@ -27,7 +27,7 @@ runc_version() {
 	if [ -n "${RUNC_REF}" ]; then
 		# just a safe-guard if this script is called when RUNC_REF was already set.
 		echo "${RUNC_REF}"
-		>&2 echo "INFO: using runc version from RUNC_REF."
+		>&2 echo "INFO: using runc version (${RUNC_REF}) from RUNC_REF."
 		return
 	fi
 
@@ -38,23 +38,23 @@ runc_version() {
 	if [ -f "${containerd_src_dir}/script/setup/runc-version" ]; then
 		# containerd v1.5.0-beta.4 and up, and v1.4.5 and up specify the version of
 		# runc to use in script/setup/runc-version.
-		cat "${containerd_src_dir}/script/setup/runc-version"
-		>&2 echo "INFO: detected runc version from script/setup/runc-version"
+		runc_ref=$(cat "${containerd_src_dir}/script/setup/runc-version")
+		>&2 echo "INFO: detected runc version (${runc_ref}) from script/setup/runc-version"
 		return
 	elif [ -f "${containerd_src_dir}/go.mod" ]; then
 		# containerd master between v1.4.x and v1.5.0-beta.4 required the runc binary
 		# to be the same version as the vendored (libcontainer) dependency, specified
 		# in go.mod. containerd v1.5.0-beta.4 (and up), and v1.4.5 (and up) decoupled
 		# the binary version from the libnetwork version, and use script/setup/runc-version
-		grep 'opencontainers/runc' "${containerd_src_dir}/go.mod" | awk '{print $2}'
-		>&2 echo "INFO: detected runc version from go.mod"
+		runc_ref=$(grep 'opencontainers/runc' "${containerd_src_dir}/go.mod" | awk '{print $2}')
+		>&2 echo "INFO: detected runc version (${runc_ref}) from go.mod"
 		return
 	elif [ -f "${containerd_src_dir}/vendor.conf" ]; then
 		# containerd master between v1.4.x and v1.5.0-beta.4 required the runc binary
 		# to be the same version as the vendored (libcontainer) dependency, specified
 		# in vendor.conf.
-		grep 'opencontainers/runc' "${containerd_src_dir}/vendor.conf" | awk '{print $2}'
-		>&2 echo "INFO: detected runc version from vendor.conf"
+		runc_ref=$(grep 'opencontainers/runc' "${containerd_src_dir}/vendor.conf" | awk '{print $2}')
+		>&2 echo "INFO: detected runc version (${runc_ref}) from vendor.conf"
 		return
 	fi
 


### PR DESCRIPTION
When testing the script locally from a clean state, I noticed that the RUNC_REF
variable was not working as expected, and failed to pick the runc version that
is set in containerd.

This patch fixes the runc version not being detected correctly.

While Make "promises" to expand variables "when used", it actually performs
this earlier than that, so when combining, it evaluates `$(SOME_VAR)` *before*
the target is run....

From the docs: https://www.gnu.org/software/make/manual/html_node/Flavors.html#Flavors

> references are expanded whenever this variable is substituted (in the course
> of expanding some other string). When this happens, it is called recursive expansion.

However, taking the following Makefile:

```make
SOME_VAR=$(shell cat hello)

.PHONY: clean
clean:
    @rm hello

.PHONY: together
together:
    @echo this is hello > hello
    @cat hello
    @echo SOME_VAR is \""$(SOME_VAR)"\"

.PHONY: separate
separate: one two

.PHONY: one
one:
    @echo this is hello > hello
    @cat hello

.PHONE: two
two:
    @echo SOME_VAR is \""$(SOME_VAR)"\"
```

When combined:

```bash
$ make clean
$ make together
cat: hello: No such file or directory
this is hello
SOME_VAR is ""
```

As shown, `$(SOME_VAR)` is evaluated *before* `together` is run, and produces
an error, because "hello" is not yet created.

When doing creating the file and using the file separate, things work as
expected, and `$(SOME_VAR)` is able to read the file:

```bash
$ make clean
$ make separate
this is hello
SOME_VAR is "this is hello"
```