### PR TITLE
Fix missing echo in scripts/determine-runc-version

### DIFF
--- a/scripts/determine-runc-version
+++ b/scripts/determine-runc-version
@@ -40,6 +40,7 @@ runc_version() {
 		# runc to use in script/setup/runc-version.
 		runc_ref=$(cat "${containerd_src_dir}/script/setup/runc-version")
 		>&2 echo "INFO: detected runc version (${runc_ref}) from script/setup/runc-version"
+		echo "${runc_ref}"
 		return
 	elif [ -f "${containerd_src_dir}/go.mod" ]; then
 		# containerd master between v1.4.x and v1.5.0-beta.4 required the runc binary
@@ -48,6 +49,7 @@ runc_version() {
 		# the binary version from the libnetwork version, and use script/setup/runc-version
 		runc_ref=$(grep 'opencontainers/runc' "${containerd_src_dir}/go.mod" | awk '{print $2}')
 		>&2 echo "INFO: detected runc version (${runc_ref}) from go.mod"
+		echo "${runc_ref}"
 		return
 	elif [ -f "${containerd_src_dir}/vendor.conf" ]; then
 		# containerd master between v1.4.x and v1.5.0-beta.4 required the runc binary
@@ -55,6 +57,7 @@ runc_version() {
 		# in vendor.conf.
 		runc_ref=$(grep 'opencontainers/runc' "${containerd_src_dir}/vendor.conf" | awk '{print $2}')
 		>&2 echo "INFO: detected runc version (${runc_ref}) from vendor.conf"
+		echo "${runc_ref}"
 		return
 	fi
 


### PR DESCRIPTION
This was introduced in e1b2c4a0e7437e63b018829deb4d0e79e8065205 (https://github.com/docker/containerd-packaging/pull/235), where the version that was found is now stored in a variable (runc_ref) for debugging.

However, I forgot to add an "echo" to actually print the version.

Because of that, the script debugs the version it found:

    + git -C src/github.com/containerd/containerd checkout -q refs/tags/v1.4.6
    ./scripts/checkout.sh src/github.com/opencontainers/runc "$(./scripts/determine-runc-version)"
    INFO: detected runc version (v1.0.0-rc95) from script/setup/runc-version

But in the "build" target it shows that it didn't actually print it
(note the missing version missing between `runc :` and `(commit: ...)`):

    --------------------------------------------------------------------
    Building packages on docker.io/dockereng/rhel:7-s390x

    containerd   : v1.4.6 (commit: d71fcd7)
    INFO: detected runc version (v1.0.0-rc95) from script/setup/runc-version
    runc         :  (commit: e005fee)
    architecture : s390x
    build image  : docker.io/dockereng/rhel:7-s390x
    golang image : docker.io/library/golang:1.13.15-buster
    --------------------------------------------------------------------

