### PR TITLE
deb: fix use of PREFIX and DESTDIR for changes in containerd

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,9 +19,12 @@
 
 # GO_SRC_PATH and PACKAGE are defined in the dockerfile
 # VERSION and REF are defined in scripts/build-deb
+# TODO remove custom PREFIX variable once containerd release/1.4 and release/1.5
+#      are obsolete. See https://github.com/containerd/containerd/commit/b5f530a157
 binaries: ## Create containerd binaries
 	@set -x; GO111MODULE=off make -C $(GO_SRC_PATH) --no-print-directory \
 		DESTDIR="$$(pwd)" \
+		PREFIX="" \
 		VERSION=$${VERSION} \
 		REVISION=$${REF} \
 		PACKAGE=$${PACKAGE} \


### PR DESCRIPTION
related: https://github.com/containerd/containerd/pull/5662


containerd commit https://github.com/containerd/containerd/commit/b5f530a15780ee443b8c568200d37d50d0449672 (https://github.com/containerd/containerd/pull/5535, https://github.com/containerd/containerd/pull/5577) changed the handling of PREFIX and DESTDIR. As a result, the location in which the binaries are installed changed.

This patch sets the PREFIX variable to match the old location, so that the build script can work with both the 1.4 and 1.5 release branches of containerd, and with current master/main.

Once the upstream 1.4 and 1.5 release branches become obsolete, we should consider removing the custom PREFIX, and use (pwd)/usr/local/bin instead, and consider using a TEMP dir for the binaries (and set that as DESTDIR).
