### PR TITLE
deb: add override_dh_strip to disable stripping binaries

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -49,6 +49,10 @@ man: ## Create containerd man pages
 
 override_dh_auto_build: binaries bin/runc man
 
+override_dh_strip:
+	# strip disabled as golang upstream doesn't support it and it makes go
+	# crash. See https://launchpad.net/bugs/1200255.
+
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade
 	sed -i 's/_dh_action=try-restart/_dh_action=restart/g' ./debian/containerd.io.postinst.debhelper


### PR DESCRIPTION
We had this override in place for the docker engine packaging (https://github.com/docker/docker-ce-packaging/blob/4cd3a7eca2f7887b15e98c2e67be1880f337d291/deb/common/rules#L42-L43, and in upstream moby (before packaging was moved); https://github.com/moby/moby/blob/v1.10.0/hack/make/.build-deb/rules#L19-L21), and I noticed it was missing here. This looks still relevant though, so adding here as well.

Comment was taken from the https://github.com/git-lfs/git-lfs repository, which had a link with more information :)
