### PR TITLE
RPM : Update libseccomp dependency name for SLES/openSUSE distros

### DIFF
--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -59,6 +59,10 @@ Source3: runc
 Requires: container-selinux >= 2:2.74
 %endif
 Requires: libseccomp
+%else
+# SUSE flavors do not have container-selinux,
+# and libseccomp is named libseccomp2
+Requires: libseccomp2
 %endif
 BuildRequires: make
 BuildRequires: gcc


### PR DESCRIPTION
Added check for suse_version to install dependencies.
