### PR TITLE
prepare release v1.4.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+containerd.io (1.4.7-1) release; urgency=medium
+
+  * Update to containerd 1.4.7
+  * Update runc to v1.0.0
+  * Update Golang runtime to 1.15.14
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Mon, 19 Jul 2021 09:30:34 +0000
+
 containerd.io (1.4.6-1) release; urgency=high
 
   * Update to containerd 1.4.6

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -161,6 +161,11 @@ done
 
 
 %changelog
+* Mon Jul 19 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.7-3.1
+- Update to containerd 1.4.7
+- Update runc to v1.0.0
+- Update Golang runtime to 1.15.14
+
 * Fri May 21 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.6-3.1
 - Update to containerd 1.4.6
 - Update runc to v1.0.0-rc95 to address CVE-2021-30465.


### PR DESCRIPTION
- Update to containerd 1.4.7
- Update runc to v1.0.0
- Update Golang runtime to 1.15.14

containerd:

- diff: https://github.com/containerd/containerd/compare/v1.4.6...v1.4.7
- release notes: https://github.com/containerd/containerd/releases/tag/v1.4.7

runc:

- diff: https://github.com/opencontainers/runc/compare/v1.0.0-rc95...v1.0.0
- release notes: https://github.com/opencontainers/runc/releases/tag/v1.0.0

golang:

- release notes: https://golang.org/doc/devel/release#go1.15

