### PR TITLE
rpm: fix repository-file names on CentOS

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -35,10 +35,11 @@ RUN yum install -y yum-utils rpm-build git
 FROM redhat-base AS rhel-base
 
 FROM redhat-base AS centos-base
-RUN if [ -f /etc/yum.repos.d/CentOS-PowerTools.repo ]; then sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-PowerTools.repo; fi
+# Using a wildcard: CentOS 7 uses "CentOS-RepoName", CentOS 8 uses "CentOS-Linux-RepoName"
+RUN if [ -f /etc/yum.repos.d/CentOS-*PowerTools.repo ]; then sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-*PowerTools.repo; fi
 # In aarch64 (arm64) images, the altarch repo is specified as repository, but
 # failing, so replace the URL.
-RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo; fi
+RUN if [ -f /etc/yum.repos.d/CentOS-*Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-*Sources.repo; fi
 
 FROM redhat-base AS amzn-base
 


### PR DESCRIPTION
relates to https://github.com/docker/containerd-packaging/pull/163
relates to https://github.com/docker/docker-ce-packaging/pull/513

Names of these files changed a couple of times (lowercase/uppercase). And differ between CentOS 7 and CentOS 8:

On CentOS 7:

    docker run --rm centos:7 ls -1 /etc/yum.repos.d/
    CentOS-Base.repo
    CentOS-CR.repo
    CentOS-Debuginfo.repo
    CentOS-Media.repo
    CentOS-Sources.repo
    CentOS-Vault.repo
    CentOS-fasttrack.repo
    CentOS-x86_64-kernel.repo

On CentOS 8, the files were renamed, and now have `-Linux` in their names:

    docker run --rm centos:8 ls -1 /etc/yum.repos.d/
    CentOS-Linux-AppStream.repo
    CentOS-Linux-BaseOS.repo
    CentOS-Linux-ContinuousRelease.repo
    CentOS-Linux-Debuginfo.repo
    CentOS-Linux-Devel.repo
    CentOS-Linux-Extras.repo
    CentOS-Linux-FastTrack.repo
    CentOS-Linux-HighAvailability.repo
    CentOS-Linux-Media.repo
    CentOS-Linux-Plus.repo
    CentOS-Linux-PowerTools.repo
    CentOS-Linux-Sources.repo

