### PR TITLE
prepare release v1.4.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.4.8-1) release; urgency=high
+
+  * Update to containerd 1.4.8 to address CVE-2021-32760
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Mon, 19 Jul 2021 19:03:08 +0000
+
 containerd.io (1.4.7-1) release; urgency=medium
 
   * Update to containerd 1.4.7

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -161,6 +161,9 @@ done
 
 
 %changelog
+* Mon Jul 19 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.8-3.1
+- Update to containerd 1.4.8 to address CVE-2021-32760
+
 * Mon Jul 19 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.7-3.1
 - Update to containerd 1.4.7
 - Update runc to v1.0.0


### PR DESCRIPTION
Update to containerd 1.4.8 to address [CVE-2021-32760][1].

[1]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32760
