### PR TITLE
RunC has been excluded from rpm spec

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -87,7 +87,6 @@ ARG CREATE_ARCHIVE
 RUN --mount=type=bind,from=golang,source=/usr/local/go/,target=/usr/local/go/ \
     --mount=type=bind,source=/src,target=/go/src,rw \
     --mount=type=bind,source=/src/github.com/containerd/containerd,target=/root/rpmbuild/SOURCES/containerd \
-    --mount=type=bind,source=/src/github.com/opencontainers/runc,target=/root/rpmbuild/SOURCES/runc \
     /root/build-rpm
 ARG UID=0
 ARG GID=0
@@ -116,6 +115,7 @@ RUN createrepo /build \
  && rm -rf /build/repodata
 RUN containerd --version
 RUN ctr --version
+RUN dnf -y install runc
 RUN runc --version
 
 FROM scratch AS packages

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -146,6 +146,9 @@ done
 
 
 %changelog
+* Mon Jul 20 2021 Alexandr Arefev <alexarefev@ya.ru> - 1.4.8-3.1
+- Runc has been excluded from rpm package
+
 * Mon Jul 19 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.8-3.1
 - Update to containerd 1.4.8 to address CVE-2021-32760
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -26,22 +26,22 @@ AutoReq: no
 %define SHA256SUM0 08f057ece7e518b14cce2e9737228a5a899a7b58b78248a03e02f4a6c079eeaf
 %global import_path github.com/containerd/containerd
 %global gopath %{getenv:GOPATH}
-%global runc_nokmem %{getenv:RUNC_NOKMEM}
+#%global runc_nokmem %{getenv:RUNC_NOKMEM}
 
 Name: containerd.io
 Provides: containerd
 # For some reason on rhel 8 if we "provide" runc then it makes this package unsearchable
-%if 0%{!?el8:1}
-Provides: runc
-%endif
+#%if 0%{!?el8:1}
+#Provides: runc
+#%endif
 
 # Obsolete packages
 Obsoletes: containerd
-Obsoletes: runc
+#Obsoletes: runc
 
 # Conflicting packages
 Conflicts: containerd
-Conflicts: runc
+#Conflicts: runc
 
 Version: %{getenv:RPM_VERSION}
 Release: %{getenv:RPM_RELEASE_VERSION}%{?dist}
@@ -51,7 +51,7 @@ URL: https://containerd.io
 Source0: containerd
 Source1: containerd.service
 Source2: containerd.toml
-Source3: runc
+#Source3: runc
 # container-selinux isn't a thing in suse flavors
 %if %{undefined suse_version}
 # amazonlinux2 doesn't have container-selinux either
@@ -97,10 +97,10 @@ fi
 # symlink the go source path to our build directory
 ln -s /go/src/%{import_path} %{_topdir}/BUILD
 
-if [ ! -d %{_topdir}/SOURCES/runc ]; then
-    # Copy over our source code from our gopath to our source directory
-    cp -rf /go/src/github.com/opencontainers/runc %{_topdir}/SOURCES/runc
-fi
+#if [ ! -d %{_topdir}/SOURCES/runc ]; then
+#    # Copy over our source code from our gopath to our source directory
+#    cp -rf /go/src/github.com/opencontainers/runc %{_topdir}/SOURCES/runc
+#fi
 cd %{_topdir}/BUILD/
 
 
@@ -120,7 +120,7 @@ rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
 
-GO111MODULE=off make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin BUILDTAGS='seccomp apparmor selinux %{runc_nokmem}' runc install
+#GO111MODULE=off make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin BUILDTAGS='seccomp apparmor selinux %{runc_nokmem}' runc install
 
 
 %install

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -26,22 +26,15 @@ AutoReq: no
 %define SHA256SUM0 08f057ece7e518b14cce2e9737228a5a899a7b58b78248a03e02f4a6c079eeaf
 %global import_path github.com/containerd/containerd
 %global gopath %{getenv:GOPATH}
-#%global runc_nokmem %{getenv:RUNC_NOKMEM}
 
 Name: containerd.io
 Provides: containerd
-# For some reason on rhel 8 if we "provide" runc then it makes this package unsearchable
-#%if 0%{!?el8:1}
-#Provides: runc
-#%endif
 
 # Obsolete packages
 Obsoletes: containerd
-#Obsoletes: runc
 
 # Conflicting packages
 Conflicts: containerd
-#Conflicts: runc
 
 Version: %{getenv:RPM_VERSION}
 Release: %{getenv:RPM_RELEASE_VERSION}%{?dist}
@@ -51,7 +44,6 @@ URL: https://containerd.io
 Source0: containerd
 Source1: containerd.service
 Source2: containerd.toml
-#Source3: runc
 # container-selinux isn't a thing in suse flavors
 %if %{undefined suse_version}
 # amazonlinux2 doesn't have container-selinux either
@@ -97,10 +89,6 @@ fi
 # symlink the go source path to our build directory
 ln -s /go/src/%{import_path} %{_topdir}/BUILD
 
-#if [ ! -d %{_topdir}/SOURCES/runc ]; then
-#    # Copy over our source code from our gopath to our source directory
-#    cp -rf /go/src/github.com/opencontainers/runc %{_topdir}/SOURCES/runc
-#fi
 cd %{_topdir}/BUILD/
 
 
@@ -119,9 +107,6 @@ GO111MODULE=off make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISIO
 rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
-
-#GO111MODULE=off make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin BUILDTAGS='seccomp apparmor selinux %{runc_nokmem}' runc install
-
 
 %install
 cd %{_topdir}/BUILD


### PR DESCRIPTION
The issue with RHEL has been described in
https://github.com/docker/containerd-packaging/pull/231