### PR TITLE
prepare release v1.4.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.4.9-1) release; urgency=medium
+
+  * Update to containerd 1.4.8
+  * Update runc to v1.0.1
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Thu, 29 Jul 2021 20:43:55 +0000
+
 containerd.io (1.4.8-1) release; urgency=high
 
   * Update to containerd 1.4.8 to address CVE-2021-32760

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -161,6 +161,10 @@ done
 
 
 %changelog
+* Thu Jul 29 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.9-3.1
+- Update to containerd 1.4.9
+- Update runc to v1.0.1
+
 * Mon Jul 19 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.8-3.1
 - Update to containerd 1.4.8 to address CVE-2021-32760
 


### PR DESCRIPTION
- Update to containerd 1.4.9
- Update runc to v1.0.1

Welcome to the v1.4.9 release of containerd!

The ninth patch release for containerd 1.4 updates runc to 1.0.1 and contains
other minor updates.

Notable Updates

- Update runc binary to 1.0.1
- Update pull authorization logic on redirect
- Fix user agent used for fetching registry authentication tokens
