### PR TITLE
Use GO111MODULE=auto instead of "off"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,7 @@
 # TODO remove custom PREFIX variable once containerd release/1.4 and release/1.5
 #      are obsolete. See https://github.com/containerd/containerd/commit/b5f530a157
 binaries: ## Create containerd binaries
-	@set -x; GO111MODULE=off make -C $(GO_SRC_PATH) --no-print-directory \
+	@set -x; GO111MODULE=auto make -C $(GO_SRC_PATH) --no-print-directory \
 		DESTDIR="$$(pwd)" \
 		PREFIX="" \
 		VERSION=$${VERSION} \
@@ -34,13 +34,13 @@ binaries: ## Create containerd binaries
 	rm -f bin/containerd-stress
 
 bin/runc:
-	@set -x; GO111MODULE=off make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
+	@set -x; GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
 		BINDIR="$$(pwd)/bin" \
 		BUILDTAGS='seccomp apparmor selinux' \
 		runc install
 
 man: ## Create containerd man pages
-	@set -x; GO111MODULE=off make -C $(GO_SRC_PATH) --no-print-directory man
+	@set -x; GO111MODULE=auto make -C $(GO_SRC_PATH) --no-print-directory man
 
 	# copy the generated man pages instead of using "make install-man" to allow
 	# dh_installman doing its magic

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -106,21 +106,21 @@ cd %{_topdir}/BUILD/
 
 %build
 cd %{_topdir}/BUILD
-GO111MODULE=off make man
+GO111MODULE=auto make man
 
 BUILDTAGS="seccomp selinux"
 %if 1%{!?el8:1}
 BUILDTAGS="${BUILDTAGS} no_btrfs"
 %endif
 
-GO111MODULE=off make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} BUILDTAGS="${BUILDTAGS}"
+GO111MODULE=auto make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} BUILDTAGS="${BUILDTAGS}"
 
 # Remove containerd-stress, as we're not shipping it as part of the packages
 rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
 
-GO111MODULE=off make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin BUILDTAGS='seccomp apparmor selinux %{runc_nokmem}' runc install
+GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin BUILDTAGS='seccomp apparmor selinux %{runc_nokmem}' runc install
 
 
 %install


### PR DESCRIPTION
relates to https://github.com/containerd/containerd/issues/6016

Using "auto" to work around an issue with a broken vendor package in
containerd;

    GO111MODULE=off make -C /go/src/github.com/containerd/containerd --no-print-directory DESTDIR=/root/containerd PREFIX= VERSION=20210916.065010~7ddf5e5 REVISION=7ddf5e52ba738e868b70807797c79c8e54da3497 PACKAGE=containerd.io binaries install
    vendor/go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/connection/connection.go:33:2:
    found import comments "go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig" (options.go)
    and "go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/otlpconfig" (optiontypes.go)
    in /go/src/github.com/containerd/containerd/vendor/go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/otlpconfig

Using "auto" should (I hope) still use the vendored packages, but instead of
"GOPATH" mode, will be using "go modules" mode, which ignores `// import`
comments (which isn't a thing in go modules).

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>