### PR TITLE
prepare release v1.4.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,14 @@
+containerd.io (1.4.10-1) release; urgency=medium
+
+  * Update to containerd 1.4.10
+  * Update runc to v1.0.2
+  * Update Golang runtime to 1.16.8
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Thu, 30 Sep 2021 15:21:28 +0000
+
 containerd.io (1.4.9-1) release; urgency=medium
 
-  * Update to containerd 1.4.8
+  * Update to containerd 1.4.9
   * Update runc to v1.0.1
 
  -- Sebastiaan van Stijn <thajeztah@docker.com>  Thu, 29 Jul 2021 20:43:55 +0000

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -161,6 +161,11 @@ done
 
 
 %changelog
+* Thu Sep 30 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.10-3.1
+- Update to containerd 1.4.10
+- Update runc to v1.0.2
+- Update Golang runtime to 1.16.8
+
 * Thu Jul 29 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.9-3.1
 - Update to containerd 1.4.9
 - Update runc to v1.0.1


### PR DESCRIPTION
- Update to containerd 1.4.10
- Update runc to v1.0.2
- Update Golang runtime to 1.16.8
