### PR TITLE
windows: fix go modules setting

### DIFF
--- a/dockerfiles/win.dockerfile
+++ b/dockerfiles/win.dockerfile
@@ -12,9 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG  GOLANG_IMAGE
-FROM ${GOLANG_IMAGE}
-ENV  chocolateyUseWindowsCompression=false
+ARG GOLANG_IMAGE=golang:latest
+FROM ${GOLANG_IMAGE} AS golang
+ARG GO111MODULE=on
+ENV GO111MODULE=$GO111MODULE \
+    chocolateyUseWindowsCompression=false
 # Install make and gcc
 RUN  iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
      choco feature disable --name showDownloadProgress; \


### PR DESCRIPTION
similar to https://github.com/docker/containerd-packaging/pull/249

    make bin/containerd
    + bin/containerd
    go: cannot find main module, but found vendor.conf in C:\gopath\src\github.com\containerd\containerd
    	to create a module there, run:
    	go mod init
