### PR TITLE
Update cpuguy83/go-md2man to v2.0.1

### DIFF
--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -25,7 +25,7 @@ FROM ${GOLANG_IMAGE} AS golang
 FROM golang AS go-md2man
 ARG GOPROXY=direct
 ARG GO111MODULE=on
-ARG MD2MAN_VERSION=v2.0.0
+ARG MD2MAN_VERSION=v2.0.1
 RUN go get github.com/cpuguy83/go-md2man/v2/@${MD2MAN_VERSION}
 
 FROM ${BUILD_IMAGE} AS distro-image

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -26,7 +26,7 @@ FROM ${GOLANG_IMAGE} AS golang
 FROM golang AS go-md2man
 ARG GOPROXY=direct
 ARG GO111MODULE=on
-ARG MD2MAN_VERSION=v2.0.0
+ARG MD2MAN_VERSION=v2.0.1
 RUN go get github.com/cpuguy83/go-md2man/v2/@${MD2MAN_VERSION}
 
 FROM ${BUILD_IMAGE} AS redhat-base


### PR DESCRIPTION
full diff: https://github.com/cpuguy83/go-md2man/compare/v2.0.0...v2.0.1

- Fix handling multiple definition descriptions
- Fix inline markup causing table cells to split
- Remove escaping tilde character (prevents tildes (`~`) from disappearing).
- Do not escape dash, underscore, and ampersand (prevents ampersands (`&`) from disappearing).
- Ignore unknown HTML tags to prevent noisy warnings

With this, generating manpages becomes a lot less noisy; no more of these:

    WARNING: go-md2man does not handle node type HTMLSpan
    WARNING: go-md2man does not handle node type HTMLSpan
    WARNING: go-md2man does not handle node type HTMLSpan

