### PR TITLE
prepare release v1.4.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.4.11-1) release; urgency=high
+
+  * Update to containerd 1.4.11 to address CVE-2021-41103
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Mon, 04 Oct 2021 11:20:49 +0000
+
 containerd.io (1.4.10-1) release; urgency=medium
 
   * Update to containerd 1.4.10

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -161,6 +161,9 @@ done
 
 
 %changelog
+* Mon Oct 04 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.11-3.1
+- Update to containerd 1.4.11 to address CVE-2021-41103
+
 * Thu Sep 30 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.10-3.1
 - Update to containerd 1.4.10
 - Update runc to v1.0.2


### PR DESCRIPTION
Update to containerd 1.4.11 to address CVE-2021-41103

https://github.com/containerd/containerd/releases/tag/v1.4.11
