### PR TITLE
Jenkinsfile: add Ubuntu 21.10 "Impish Indri"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ def images = [
     [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [image: "docker.io/library/ubuntu:hirsute",         arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 21.04 (EOL: January, 2022)
+    [image: "docker.io/library/ubuntu:impish",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 21.10 (EOL: July, 2022)
 ]
 
 def generatePackageStep(opts, arch) {


### PR DESCRIPTION
Released on 14 October 2021: https://ubuntu.com/blog/ubuntu-21-10-has-landed


related PR for ce-packaging; https://github.com/docker/docker-ce-packaging/pull/585