### PR TITLE
deb: force dpkg-build to use xz compression instead of zstd

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -47,6 +47,11 @@ man: ## Create containerd man pages
 	install -d man
 	install -D -m 0644 $(GO_SRC_PATH)/man/* man
 
+# force packages to be built with xz compression, as Ubuntu 21.10 and up use
+# zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 override_dh_auto_build: binaries bin/runc man
 
 override_dh_systemd_start:


### PR DESCRIPTION
Ubuntu 21.10 switched the default compression for .deb packages to use zstd.
While this change may bring some performance improvement, it is non-standard,
and not all deb-related tooling currently support zstd compression. One of those
tools, dpkg-sig, has not (yet) been modified to support zstd compression; we use
this tool to sign our packages (and verify that packages are signed), which
currently fails if packages use zstd compression;

    dpkg-sig --verify ./containerd.io_1.4.11-1_amd64.deb
    Processing ./containerd.io_1.4.11-1_amd64.deb...
    BADSIG _gpgbuilder

It should be noted that signing individual packages is *optional* [1], and that
dpkg-sig has not received updates since 2006 [2] (possibly better replaced with
debsigs / debsig-verify), but changing would be a potential breaking change, as
these tools are not interchangeable [3]

[1]: https://www.debian.org/doc/manuals/securing-debian-manual/deb-pack-sign.en.html
[2]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=995113
[3]: https://raphaelhertzog.com/2010/09/17/how-to-create-debian-packages-with-alternative-compression-methods/

This patch hard-codes the compression to use in the debian rules, instead of using
the default that's used by the distro. xz appears to be the previous default for
Ubuntu and Debian; to verify this does not change the compression used for other
distros, I did a quick check of the existing packages;

    curl -O https://download.docker.com/linux/debian/dists/bullseye/pool/stable/amd64/containerd.io_1.4.11-1_amd64.deb
    ar t .containerd.io_1.4.11-1_amd64.deb
    debian-binary
    control.tar.xz
    data.tar.xz
    _gpgbuilder

From a size perspective, it looks like xz is actually smaller than zstd, so no
negative effect there;

With zstd compression:

    -rw-r--r--  1 sebastiaan  staff    25M Oct 19 14:43 ./build/ubuntu/impish/amd64/containerd.io_1.4.11-1_amd64.deb

With xz compression:

    -rw-r--r--  1 sebastiaan  staff    23M Oct 19 23:56 ./build/ubuntu/impish/amd64/containerd.io_1.4.11-1_amd64.deb

Before this change:

    make docker.io/library/ubuntu:impish
    ar t ./build/ubuntu/impish/amd64/*.deb
    debian-binary
    control.tar.zst
    data.tar.zst
    _gpgbuilder

After this change:

    make docker.io/library/ubuntu:impish
    ar t ./build/ubuntu/impish/amd64/*.deb
    debian-binary
    control.tar.xz
    data.tar.xz

