### PR TITLE
Jenkinsfile: remove s390x steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@
 def images = [
     [image: "docker.io/library/amazonlinux:2",          arches: ["aarch64"]],
     [image: "docker.io/library/centos:7",               arches: ["amd64", "aarch64"]],
-    [image: "docker.io/dockereng/rhel:7-s390x",         arches: ["s390x"]],
     [image: "docker.io/library/centos:8",               arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
     [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (Next stable)
@@ -19,7 +18,7 @@ def images = [
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
     [image: "docker.io/balenalib/rpi-raspbian:buster",  arches: ["armhf"]],
     [image: "docker.io/balenalib/rpi-raspbian:bullseye",arches: ["armhf"]],
-    [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "armhf", "s390x"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
+    [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [image: "docker.io/library/ubuntu:hirsute",         arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 21.04 (EOL: January, 2022)
     [image: "docker.io/library/ubuntu:impish",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 21.10 (EOL: July, 2022)


### PR DESCRIPTION
Packages for s390x are built by IBM, and the RHEL image that we used was outdated/broken, so made CI fail.
