### PR TITLE
Makefile: add target for quay.io images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,11 @@ endif
 # This targets allows building multiple distros at once, for example:
 #
 #     make docker.io/library/ubuntu:bionic docker.io/library/centos:7
+#     make quay.io/centos/centos:stream8
 #
 # It is a shorthand for "make BUILD_IMAGE=mydistro:version build"
-.PHONY: docker.io/%
-docker.io/%:
+.PHONY: docker.io/% quay.io/%
+docker.io/% quay.io/%:
 	$(MAKE) BUILD_IMAGE="$@" build
 
 .PHONY: checkout


### PR DESCRIPTION
This allows building packages using base-images from quay.io, for example to
build for CentOS 8 stream (which is not (yet) on Docker Hub);

    make quay.io/centos/centos:stream8

    tree build
    build
    └── centos
        └── 8
            └── x86_64
                ├── containerd.io-0.20220208.013149~6a628b6-0.el8.src.rpm
                └── containerd.io-0.20220208.013149~6a628b6-0.el8.x86_64.rpm

    3 directories, 2 files

