### PR TITLE
Jenkinsfile: switch CentOS 8 to "stream"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@
 def images = [
     [image: "docker.io/library/amazonlinux:2",          arches: ["aarch64"]],
     [image: "docker.io/library/centos:7",               arches: ["amd64", "aarch64"]],
-    [image: "docker.io/library/centos:8",               arches: ["amd64", "aarch64"]],
+    [image: "quay.io/centos/centos:stream8",            arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
     [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (Next stable)
     [image: "docker.io/library/fedora:34",              arches: ["amd64", "aarch64"]],          // EOL: May 17, 2022


### PR DESCRIPTION
follow-up to https://github.com/docker/containerd-packaging/pull/263

CentOS 8 reached EOL in December, and the package repositories are no longer
available (at least, not all repositories, some are available as archive).

This switches the centos 8 builds to build packages using the
quay.io/centos/centos:stream8 image (which is not (yet) on Docker Hub);

    make quay.io/centos/centos:stream8

    tree build
    build
    └── centos
        └── 8
            └── x86_64
                ├── containerd.io-0.20220208.013149~6a628b6-0.el8.src.rpm
                └── containerd.io-0.20220208.013149~6a628b6-0.el8.x86_64.rpm

    3 directories, 2 files
