### PR TITLE
Makefile: clean: also remove "archive" directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,11 @@ all: build
 
 .PHONY: clean
 clean:
-	-$(RM) -r build/
-	-$(RM) common/containerd.service
+	-$(RM) -r archive
 	-$(RM) -r artifacts
+	-$(RM) -r build
 	-$(RM) -r src
+	-$(RM) common/containerd.service
 	-docker builder prune -f --filter until=24h
 
 .PHONY: src


### PR DESCRIPTION
This directory is used when CREATE_ARCHIVE=1 is set, but wasn't
cleaned up when runnning `make clean`.
