### PR TITLE
Makefile: allow GOVERSION to be passed, but being empty

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -19,6 +19,16 @@ RUNC_REMOTE       ?=https://github.com/opencontainers/runc.git
 REF?=HEAD
 
 # Select the default version of Golang and runc based on the containerd source.
-GOVERSION?=$(shell grep "ARG GOLANG_VERSION" src/github.com/containerd/containerd/contrib/Dockerfile.test | awk -F'=' '{print $$2}')
+GOLANG_VERSION?=$(shell grep "ARG GOLANG_VERSION" src/github.com/containerd/containerd/contrib/Dockerfile.test | awk -F'=' '{print $$2}')
 
-GOLANG_IMAGE=golang:$(GOVERSION)
+# Allow GOLANG_VERSION to be overridden through GOVERSION.
+#
+# We're using a separate variable for this to account for make being called as
+# either `GOVERSION=x make foo` or `make GOVERSION=x foo`, while also accounting
+# for `GOVERSION` to be an empty string (which may happen when triggered by some
+# Jenkins jobs in our pipeline).
+ifneq ($(strip $(GOVERSION)),)
+	GOLANG_VERSION=$(GOVERSION)
+endif
+
+GOLANG_IMAGE=golang:$(GOLANG_VERSION)

--- a/common/common.mk
+++ b/common/common.mk
@@ -27,4 +27,3 @@ ifeq ($(OS),Windows_NT)
 else
        GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)-buster
 endif
-GOARCH=$(shell docker run --rm $(GOLANG_IMAGE) go env GOARCH 2>/dev/null)

--- a/common/common.mk
+++ b/common/common.mk
@@ -22,8 +22,3 @@ REF?=HEAD
 GOVERSION?=$(shell grep "ARG GOLANG_VERSION" src/github.com/containerd/containerd/contrib/Dockerfile.test | awk -F'=' '{print $$2}')
 
 GOLANG_IMAGE=golang:$(GOVERSION)
-ifeq ($(OS),Windows_NT)
-       GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)
-else
-       GOLANG_IMAGE=docker.io/library/golang:$(GOVERSION)-buster
-endif


### PR DESCRIPTION
## Makefile: remove unused GOARCH variable

This variable was previously used to generate the `BUILDER_IMAGE` variable, but appears to be unused since commit 018f1b9384e881a8a6157207615a941c15fb15b3 (https://github.com/docker/containerd-packaging/pull/154)

## Makefile: remove workaround for s390x GOLANG_IMAGE

This workaround was added in d1225f65c3cde07915d9c8a116e096b043921d5a (https://github.com/docker/containerd-packaging/pull/140), and from the related PR;

> This is a workaround for golang:1.12.x images where the manifest list is missing
> s390x. With golang:1.13.x or newer this if block can ve removed again.

## Makefile: allow GOVERSION to be passed, but being empty

Some of our Jenkins jobs allow for GOVERSION to be set as parameter but
unconditionally pass the variable when calling `make` from this repository.
The intent of those parameters was to allow overriding the Go version when
building packages, but due to the parameter to be passed unconditionally,
curently requires us to always set the Go version to build, and making sure
it's set to the correct version for containerd to build.

Make (unfortunately) seems to make it nigh impossible to detect if a variable
is either unset (not passed) or empty, while also accounting for the variable
to be passed as `FOO= make <target>` and `make FOO= <target>` _and_ allowing
the default value to be evaluated lazily (on "use"), which is needed in our
case (to get the default version from containerd's repository, which requires
the source code to be checked out first).

Variations of the below all failed (as demonstrated below);

```makefile
ifndef FOO
FOO = $(shell echo "default1")
else ifeq ($(strip $(FOO)),)
FOO = $(shell echo "default2")
endif

.PHONY: test
test:
@echo foo is "$(FOO)" from $(origin FOO)
```

```bash
$ make test
foo is default1 from file

$ FOO= make test
foo is default1 from file

$ make FOO= test
foo is from command line
```

To work around this, we're introducing separate variables for the
`GOVERSION` (to be used to override the default) and `GOLANG_VERSION`,
which is the (lazily evaluated) variable used to construct the golang
image reference to use.
