### PR TITLE
prepare release v1.4.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+containerd.io (1.4.13-1) release; urgency=high
+
+  * Update containerd to v1.4.13 to address CVE-2022-23648
+  * Update runc to v1.0.3
+  * Update Golang runtime to 1.16.15
+
+ --  Sebastiaan van Stijn <thajeztah@docker.com>  Thu, 03 Mar 2022 21:09:12 +0000
+
 containerd.io (1.4.12-1) release; urgency=high
 
   * Update containerd to v1.4.12 to address CVE-2021-41190

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -161,6 +161,11 @@ done
 
 
 %changelog
+* Thu Mar 03 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.13-3.1
+- Update containerd to v1.4.13 to address CVE-2022-23648
+- Update runc to v1.0.3
+- Update Golang runtime to 1.16.15
+
 * Wed Nov 17 2021 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.12-3.1
 - Update containerd to v1.4.12 to address CVE-2021-41190
 - Update Golang runtime to 1.16.10


### PR DESCRIPTION
- Update containerd to v1.4.13 to address CVE-2022-23648
- Update runc to v1.0.3
- Update Golang runtime to 1.16.15
