### PR TITLE
Also build for CentOS 9.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ def images = [
     [image: "docker.io/library/amazonlinux:2",          arches: ["aarch64"]],
     [image: "docker.io/library/centos:7",               arches: ["amd64", "aarch64"]],
     [image: "quay.io/centos/centos:stream8",            arches: ["amd64", "aarch64"]],
+    [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
     [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (Next stable)
     [image: "docker.io/library/fedora:34",              arches: ["amd64", "aarch64"]],          // EOL: May 17, 2022

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -30,8 +30,8 @@ AutoReq: no
 
 Name: containerd.io
 Provides: containerd
-# For some reason on rhel 8 if we "provide" runc then it makes this package unsearchable
-%if 0%{!?el8:1}
+# For some reason on rhel >= 8 if we "provide" runc then it makes this package unsearchable
+%if 0%{?rhel} <= 7
 Provides: runc
 %endif
 
@@ -69,15 +69,6 @@ BuildRequires: gcc
 BuildRequires: systemd
 BuildRequires: libseccomp-devel
 
-# Should only return true if `el8` (rhel8) is NOT defined
-%if 0%{!?el8:1}
-%if 0%{?suse_version}
-BuildRequires: libbtrfs-devel
-%else
-BuildRequires: btrfs-progs-devel
-%endif
-%endif
-
 %{?systemd_requires}
 
 %description
@@ -108,10 +99,7 @@ cd %{_topdir}/BUILD/
 cd %{_topdir}/BUILD
 GO111MODULE=auto make man
 
-BUILDTAGS="seccomp selinux"
-%if 1%{!?el8:1}
-BUILDTAGS="${BUILDTAGS} no_btrfs"
-%endif
+BUILDTAGS="seccomp selinux no_btrfs"
 
 GO111MODULE=auto make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} BUILDTAGS="${BUILDTAGS}"
 


### PR DESCRIPTION
Note: I have removed the btrfs support unconditionally as IMO the old condition "%if 1%{!?el8:1}" was always true, on every distros.

This includes changes inspired from #231.