### PR TITLE
prepare release v1.5.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.5.11-1) release; urgency=high
+
+  * Update containerd to v1.5.11 to address CVE-2022-24769
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Wed, 23 Mar 2022 18:05:21 +0000
+
 containerd.io (1.5.10-1) release; urgency=medium
 
   * Update containerd to v1.5.10

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -161,6 +161,9 @@ done
 
 
 %changelog
+* Wed Mar 23 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.5.11-3.1
+- Update containerd to v1.5.11 to address CVE-2022-24769
+
 * Fri Mar 04 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.5.10-3.1
 - Update containerd to v1.5.10
 


### PR DESCRIPTION
Update containerd to v1.5.11 to address CVE-2022-24769

not yet release; upstream PR: https://github.com/containerd/containerd/pull/6714