### PR TITLE
Dockerfile: use go install instead of go get, for go1.18 compatibility

### DIFF
--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -26,7 +26,7 @@ FROM golang AS go-md2man
 ARG GOPROXY=direct
 ARG GO111MODULE=on
 ARG MD2MAN_VERSION=v2.0.1
-RUN go get github.com/cpuguy83/go-md2man/v2/@${MD2MAN_VERSION}
+RUN go install github.com/cpuguy83/go-md2man/v2@${MD2MAN_VERSION}
 
 FROM ${BUILD_IMAGE} AS distro-image
 

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -27,7 +27,7 @@ FROM golang AS go-md2man
 ARG GOPROXY=direct
 ARG GO111MODULE=on
 ARG MD2MAN_VERSION=v2.0.1
-RUN go get github.com/cpuguy83/go-md2man/v2/@${MD2MAN_VERSION}
+RUN go install github.com/cpuguy83/go-md2man/v2@${MD2MAN_VERSION}
 
 FROM ${BUILD_IMAGE} AS redhat-base
 RUN yum install -y yum-utils rpm-build git


### PR DESCRIPTION
CI is testing against upstream's main branch by default, which switched to
go1.18 and no longer supports `go get` to install binaries (so much for
non-breaking changes!).

Switch to use `go install` instead.

    #15 [go-md2man 1/1] RUN go get github.com/cpuguy83/go-md2man/v2/@v2.0.1
    #15 sha256:3e9f814116626f2999ba8ad0d09eae1119046b63262fd889e4bbd831991c322d
    #15 0.626 go: go.mod file not found in current directory or any parent directory.
    #15 0.626 	'go get' is no longer supported outside a module.
    #15 0.626 	To build and install a command, use 'go install' with a version,
    #15 0.626 	like 'go install example.com/cmd@latest'
    #15 0.626 	For more information, see https://golang.org/doc/go-get-install-deprecation
    #15 0.626 	or run 'go help get' or 'go help install'.
    #15 ERROR: executor failed running [/bin/sh -c go get github.com/cpuguy83/go-md2man/v2/@${MD2MAN_VERSION}]: exit code: 1
