### PR TITLE
changelog: add go 1.17.8 update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,7 @@ containerd.io (1.5.11-1) release; urgency=high
 containerd.io (1.5.10-1) release; urgency=medium
 
   * Update containerd to v1.5.10
+  * Update Golang runtime to 1.17.8
 
  -- Sebastiaan van Stijn <thajeztah@docker.com>  Fri, 04 Mar 2022 17:47:48 +0000
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -166,6 +166,7 @@ done
 
 * Fri Mar 04 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.5.10-3.1
 - Update containerd to v1.5.10
+- Update Golang runtime to 1.17.8
 
 * Thu Mar 03 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.4.13-3.1
 - Update containerd to v1.4.13 to address CVE-2022-23648


### PR DESCRIPTION
upstream also updated to go 1.17.8 for the 1.5.11 release
