### PR TITLE
make validate: skip artifacts and sources

### DIFF
--- a/scripts/validate/fileheader
+++ b/scripts/validate/fileheader
@@ -24,4 +24,4 @@ fi
 
 BASEPATH="${1-}"
 
-ltag -t "${BASEPATH}scripts/validate/template" --excludes "vendor validate" --check -v
+ltag -t "${BASEPATH}scripts/validate/template" --excludes "archive artifacts build src validate vendor" --check -v


### PR DESCRIPTION
While CI won't hit this situation, when running make validate
locally, the working directory may contain a src, build, or archive
directory, which is not part of the code in this repo, so does not
have to be validated.
