### PR TITLE
scripts: fix new-deb-release on macOS, and make sure all dates are in UTC

### DIFF
--- a/scripts/build-deb
+++ b/scripts/build-deb
@@ -22,7 +22,7 @@ set -e
 VERSION="$(git --git-dir "${GO_SRC_PATH}/.git" describe --tags | sed 's/^v//')"
 # Check if we're on a tagged version, change VERSION to dev build if not
 if ! git --git-dir "${GO_SRC_PATH}/.git" describe --exact-match HEAD > /dev/null 2>&1; then
-	git_date=$(date --date "@$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%at')" +'%Y%m%d.%H%M%S')
+	git_date=$(TZ=UTC date --date "@$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%at')" +'%Y%m%d.%H%M%S')
 	git_sha=$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%h')
 	VERSION="${git_date}~${git_sha}"
 	# prepend a `0` so it'll never be greater than non-dev versions
@@ -31,7 +31,7 @@ if ! git --git-dir "${GO_SRC_PATH}/.git" describe --exact-match HEAD > /dev/null
 
 		  * Release for ${git_sha}
 
-		 -- $(control_field Maintainer)  $(date --rfc-2822)
+		 -- $(control_field Maintainer)  $(TZ=UTC date --rfc-2822)
 
 	EOF
 	cat debian/changelog >> debian/nightly.changelog

--- a/scripts/build-rpm
+++ b/scripts/build-rpm
@@ -40,7 +40,7 @@ RPM_RELEASE_VERSION=$(echo "${RPM_VER_BITS}" | cut -f2 -d' ')
 
 # Check if we're on a tagged version, change VERSION to dev build if not
 if ! git --git-dir "${GO_SRC_PATH}/.git" describe --exact-match HEAD > /dev/null 2>&1; then
-	git_date=$(date --date "@$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%at')" +'%Y%m%d.%H%M%S')
+	git_date=$(TZ=UTC date --date "@$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%at')" +'%Y%m%d.%H%M%S')
 	git_sha=$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%h')
 	VERSION="0.${git_date}~${git_sha}"
 	RPM_RELEASE_VERSION=0

--- a/scripts/new-deb-release
+++ b/scripts/new-deb-release
@@ -36,7 +36,7 @@ cat > debian/new.changelog <<- EOF
 
 	  * TODO: Insert release changes here
 
-	 -- $(git config user.name) <$(git config user.email)>  $(date -R)
+	 -- $(git config user.name) <$(git config user.email)>  $(TZ=UTC date -R)
 
 EOF
 cat debian/changelog >> debian/new.changelog

--- a/scripts/new-deb-release
+++ b/scripts/new-deb-release
@@ -36,7 +36,7 @@ cat > debian/new.changelog <<- EOF
 
 	  * TODO: Insert release changes here
 
-	 -- $(git config user.name) <$(git config user.email)>  $(date --rfc-2822)
+	 -- $(git config user.name) <$(git config user.email)>  $(date -R)
 
 EOF
 cat debian/changelog >> debian/new.changelog

--- a/scripts/new-rpm-release
+++ b/scripts/new-rpm-release
@@ -37,7 +37,7 @@ while grep "$RPM_VERSION-$RPM_RELEASE_VERSION.$RPM_ITERATION" "${SPEC_FILE}" > /
 done
 
 cat > rpm/new.changelog << EOF
-* $(date +"%a %b %d %Y") $(git config user.name) <$(git config user.email)> - $RPM_VERSION-$RPM_RELEASE_VERSION.$RPM_ITERATION
+* $(TZ=UTC date +"%a %b %d %Y") $(git config user.name) <$(git config user.email)> - $RPM_VERSION-$RPM_RELEASE_VERSION.$RPM_ITERATION
 - TODO: Insert release changes here
 
 EOF


### PR DESCRIPTION
### scripts/new-deb-release: fix date generation on macOS

macOS uses the BSD flavor of `date`, which does not support the `--rfc-2822` option, causing the script to fail and produce a changelog entry without a date.

The BSD flavor does have `-R` option, which is supported both on GNU and BSD, which provides the equivalent. From the man page on macOS:

     -R      Use RFC 2822 date and time output format. This is equivalent to use
             '%a, %d %b %Y %T %z' as output_fmt while LC_TIME is set to the
             'C' locale .

Before this patch:

    ./scripts/new-deb-release 1.2.3
    date: illegal option -- -
    usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
    [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
    ...
    containerd.io (1.2.3-1) release; urgency=medium
    
    * TODO: Insert release changes here
    
    -- Sebastiaan van Stijn <thajeztah@docker.com>


After this patch

    ./scripts/new-deb-release 1.2.3
    containerd.io (1.2.3-1) release; urgency=medium
    
    * TODO: Insert release changes here
    
    -- Sebastiaan van Stijn <thajeztah@docker.com>  Wed, 06 Apr 2022 12:06:17 +0200


### scripts: make sure all dates use UTC

While most of the dates generated were done from within a container (which defaults to using UTC), some scripts could be run on the host, and therefore depend on the host's configured timezone.

This patch makes sure that all calls to `date` use `TZ=UTC` to make sure the dates are consistent.


Before this patch:

    ./scripts/new-deb-release 1.2.3 &> /dev/null && git diff -- debian/changelog | grep Sebastiaan
    + -- Sebastiaan van Stijn <github@gone.nl>  Wed, 06 Apr 2022 12:22:09 +0200

With this patch:

    ./scripts/new-deb-release 1.2.3 &> /dev/null && git diff -- debian/changelog | grep Sebastiaan
    + -- Sebastiaan van Stijn <github@gone.nl>  Wed, 06 Apr 2022 10:22:15 +0000

