### PR TITLE
Also build for CentOS 9.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ def images = [
     [image: "docker.io/library/amazonlinux:2",          arches: ["aarch64"]],
     [image: "docker.io/library/centos:7",               arches: ["amd64", "aarch64"]],
     [image: "quay.io/centos/centos:stream8",            arches: ["amd64", "aarch64"]],
+    [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
     [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (Next stable)
     [image: "docker.io/library/fedora:34",              arches: ["amd64", "aarch64"]],          // EOL: May 17, 2022

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -30,8 +30,8 @@ AutoReq: no
 
 Name: containerd.io
 Provides: containerd
-# For some reason on rhel 8 if we "provide" runc then it makes this package unsearchable
-%if 0%{!?el8:1}
+# For some reason on rhel >= 8 if we "provide" runc then it makes this package unsearchable
+%if %{undefined rhel} || 0%{?rhel} < 8
 Provides: runc
 %endif
 
@@ -69,11 +69,12 @@ BuildRequires: gcc
 BuildRequires: systemd
 BuildRequires: libseccomp-devel
 
-# Should only return true if `el8` (rhel8) is NOT defined
-%if 0%{!?el8:1}
-%if 0%{?suse_version}
+%if %{undefined rhel} || 0%{?rhel} < 8
+%if %{defined suse_version}
+# SUSE flavors
 BuildRequires: libbtrfs-devel
 %else
+# Fedora / others, and CentOS/RHEL < 8
 BuildRequires: btrfs-progs-devel
 %endif
 %endif
@@ -109,7 +110,8 @@ cd %{_topdir}/BUILD
 GO111MODULE=auto make man
 
 BUILDTAGS="seccomp selinux"
-%if 1%{!?el8:1}
+%if %{defined rhel} && 0%{?rhel} >= 8
+# btrfs support was removed in CentOS/RHEL 8
 BUILDTAGS="${BUILDTAGS} no_btrfs"
 %endif
 


### PR DESCRIPTION
- carries https://github.com/docker/containerd-packaging/pull/270
- closes https://github.com/docker/containerd-packaging/pull/270


Changes;

- do not "provide" runc on CentOS/RHEL >= 8
- do not build btrfs on CentOS/RHEL >= 8
- set the correct build-dependency for BTRFS on SUSE flavors and "others"
