### PR TITLE
remove deprecated containerd and runc build-tags

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -36,7 +36,6 @@ binaries: ## Create containerd binaries
 bin/runc:
 	@set -x; GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
 		BINDIR="$$(pwd)/bin" \
-		BUILDTAGS='seccomp apparmor selinux' \
 		runc install
 
 man: ## Create containerd man pages

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -26,7 +26,6 @@ AutoReq: no
 %define SHA256SUM0 08f057ece7e518b14cce2e9737228a5a899a7b58b78248a03e02f4a6c079eeaf
 %global import_path github.com/containerd/containerd
 %global gopath %{getenv:GOPATH}
-%global runc_nokmem %{getenv:RUNC_NOKMEM}
 
 Name: containerd.io
 Provides: containerd
@@ -109,7 +108,7 @@ cd %{_topdir}/BUILD/
 cd %{_topdir}/BUILD
 GO111MODULE=auto make man
 
-BUILDTAGS="seccomp selinux"
+BUILDTAGS=""
 %if %{defined rhel} && 0%{?rhel} >= 8
 # btrfs support was removed in CentOS/RHEL 8
 BUILDTAGS="${BUILDTAGS} no_btrfs"
@@ -122,7 +121,7 @@ rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
 
-GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin BUILDTAGS='seccomp apparmor selinux %{runc_nokmem}' runc install
+GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin runc install
 
 
 %install

--- a/scripts/build-rpm
+++ b/scripts/build-rpm
@@ -61,14 +61,6 @@ ARCH="$(uname -m)"
 DEST_DIR="/build/${DIST_ID}/${DIST_VERSION}/${ARCH}/"
 (
 	set -x
-	# Set 'runc_nokmem' build tag for RHEL/CentOS 7.x
-	if [ "$DIST_ID" = "centos" ] || [ "$DIST_ID" = "rhel" ]; then
-		case "$DIST_VERSION" in
-		"7"*)
-			export RUNC_NOKMEM="nokmem"
-			;;
-		esac
-	fi
 	rpmbuild -ba "${SPEC_FILE}"
 	mkdir -p "${DEST_DIR}"
 	mv -v RPMS/*/*.rpm "${DEST_DIR}"


### PR DESCRIPTION
containerd and runc (no longer) use the seccomp and apparmor build-tags, and runc
has removed the runc_nokmem build-tag (now the default).

seccomp is enabled by default for containerd and runc, but can be disabled on
runc by setting BUILDTAGS to an empty string;
https://github.com/opencontainers/runc/blob/v1.1.2/README.md#build-tags

Given that we always want to include seccomp (with non-static builds), this patch
removes the BUILDTAGS altogether for runc.

For containerd, we still need a buildtag to disable btrfs on CentOS 8 and up;
https://github.com/containerd/containerd/blob/v1.6.5/BUILDING.md#build-containerd
