### PR TITLE
prepare release v1.6.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+containerd.io (1.6.5-1) release; urgency=medium
+
+  * Update containerd to v1.6.5
+  * Update runc to v1.1.2
+  * Update Golang runtime to 1.17.11
+
+ -- Sebastiaan van Stijn <thajeztah@dockercom>  Sat, 04 Jun 2022 20:56:32 +0000
+
 containerd.io (1.6.4-1) release; urgency=medium
 
   * Update containerd to v1.6.4

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -163,6 +163,11 @@ done
 
 
 %changelog
+* Sat Jun 04 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.5-3.1
+- Update containerd to v1.6.5
+- Update runc to v1.1.2
+- Update Golang runtime to 1.17.11
+
 * Wed May 04 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.4-3.1
 - Update containerd to v1.6.4
 


### PR DESCRIPTION
- Update containerd to v1.6.5
- Update runc to v1.1.2
- Update Golang runtime to 1.17.11

