### PR TITLE
prepare release v1.6.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.6.6-1) release; urgency=high
+
+  * Update containerd to v1.6.6 to address CVE-2022-31030
+
+ -- Sebastiaan van Stijn <thajeztah@dockercom>  Mon, 06 Jun 2022 20:45:21 +0000
+
 containerd.io (1.6.5-1) release; urgency=medium
 
   * Update containerd to v1.6.5

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -162,6 +162,9 @@ done
 
 
 %changelog
+* Mon Jun 06 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.6-3.1
+- Update containerd to v1.6.6 to address CVE-2022-31030
+
 * Sat Jun 04 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.5-3.1
 - Update containerd to v1.6.5
 - Update runc to v1.1.2


### PR DESCRIPTION
- Update containerd to v1.6.6 to address CVE-2022-31030
