### PR TITLE
Dockerfile: use latest stable syntax instead of experimental

### DIFF
--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:experimental
+# syntax=docker/dockerfile:1
 
 
 #   Copyright 2018-2022 Docker Inc.

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:experimental
+# syntax=docker/dockerfile:1
 
 
 #   Copyright 2018-2022 Docker Inc.


### PR DESCRIPTION
All features we use from the "experimental" syntax have been integrated into
the stable front-end, so there's no longer a need to use the experimental one;
switching to latest stable syntax to make sure we use an up-to-date version.
