### PR TITLE
openSUSE: fix installation of createrepo in validation step

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -106,7 +106,8 @@ RUN chown -R ${UID}:${GID} /archive /build
 # NOTE: Installation of source-packages is not currently tested here.
 FROM distro-image AS verify-packages
 COPY scripts/.rpm-helpers /root/
-RUN . /root/.rpm-helpers; install_package createrepo
+# On OpenSUSE/SLES, the package is now named `createrepo_c`
+RUN . /root/.rpm-helpers; if [ -d "/etc/zypp/repos.d/" ]; then install_package createrepo_c; else install_package createrepo; fi
 RUN if [ -d "/etc/zypp/repos.d/" ]; then ln -s "/etc/zypp/repos.d" "/etc/yum.repos.d"; fi \
  && echo -e "[local]\nname=Test Repo\nbaseurl=file:///build/\nenabled=1\ngpgcheck=0" >  "/etc/yum.repos.d/local.repo"
 COPY --from=build-packages /build/. /build/


### PR DESCRIPTION
- relates to https://github.com/docker/containerd-packaging/pull/288
- addresses https://github.com/docker/containerd-packaging/pull/288#issuecomment-1203809196

It looks like the `createrepo` (meta)package is no longer available on current versions
of the `opensuse/leap:15` image;

    #31 [verify-packages 2/8] RUN . /root/.rpm-helpers; install_package createrepo
    #31 sha256:2a4f1d9c47a241e657779268aab82bd68c98d9ec24a5d3df57ce6ed4f7f65671
    #31 1.811 Loading repository data...
    #31 2.618 Reading installed packages...
    #31 3.267 'createrepo' not found in package names. Trying capabilities.
    #31 3.267 No provider of 'createrepo' found.
    #31 ERROR: executor failed running [/bin/sh -c . /root/.rpm-helpers; install_package createrepo]: exit code: 104

Instead there's now 2 flavours available; a C implementation and a Python implementation;

    zypper search createrepo
    Loading repository data...
    Reading installed packages...

    S | Name                  | Summary                                        | Type
    --+-----------------------+------------------------------------------------+--------
      | createrepo_c          | RPM repository metadata generation utility     | package
      | libcreaterepo_c-devel | Library for repodata manipulation              | package
      | libcreaterepo_c0      | Library for repodata manipulation              | package
      | python3-createrepo_c  | Python 3 bindings for the createrepo_c library | package

This patch updates the Dockerfile to install the `createrepo_c` package instead
when running on (open)SUSE, using the existence of the `/etc/zypp/repos.d/` directory
to detect we're (likely) running on (open)SUSE.
