### PR TITLE
prepare release v1.6.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.6.10-1) release; urgency=medium
+
+  * Update containerd to v1.6.10
+  * Update Golang runtime to 1.18.8
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Thu, 17 Nov 2022 14:09:28 +0000
+
 containerd.io (1.6.9-1) release; urgency=medium
 
   * Update containerd to v1.6.9

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -162,6 +162,10 @@ done
 
 
 %changelog
+* Thu Nov 17 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.10-3.1
+- Update containerd to v1.6.10
+- Update Golang runtime to 1.18.8
+
 * Mon Oct 24 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.9-3.1
 - Update containerd to v1.6.9
 - Update Golang runtime to 1.18.7


### PR DESCRIPTION
- Update containerd to v1.6.10 (https://github.com/containerd/containerd/releases/tag/v1.6.10)
- Update Golang runtime to 1.18.8
