### PR TITLE
prepare release v1.6.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+containerd.io (1.6.11-1) release; urgency=medium
+
+  * Update containerd to v1.6.11
+  * Update Golang runtime to 1.18.9, which includes fixes for CVE-2022-41717,
+    CVE-2022-41720, and CVE-2022-41720.
+
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Tue, 06 Dec 2022 22:37:13 +0000
+
 containerd.io (1.6.10-1) release; urgency=medium
 
   * Update containerd to v1.6.10

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -162,6 +162,11 @@ done
 
 
 %changelog
+* Tue Dec 06 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.11-3.1
+- Update containerd to v1.6.11
+- Update Golang runtime to 1.18.9, which includes fixes for CVE-2022-41717,
+  CVE-2022-41720, and CVE-2022-41720.
+
 * Thu Nov 17 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.10-3.1
 - Update containerd to v1.6.10
 - Update Golang runtime to 1.18.8


### PR DESCRIPTION
- Update containerd to v1.6.11
- Update Golang runtime to 1.18.9, which includes fixes for CVE-2022-41717, CVE-2022-41720, and CVE-2022-41720.
