### PR TITLE
prepare release 1.6.12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.6.12-1) release; urgency=high
+
+  * Update containerd to v1.6.12 to address CVE-2022-23471
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Wed, 07 Dec 2022 23:53:03 +0000
+
 containerd.io (1.6.11-1) release; urgency=medium
 
   * Update containerd to v1.6.11

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -162,6 +162,9 @@ done
 
 
 %changelog
+* Wed Dec 07 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.12-3.1
+- Update containerd to v1.6.12 to address CVE-2022-23471
+
 * Tue Dec 06 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.11-3.1
 - Update containerd to v1.6.11
 - Update Golang runtime to 1.18.9, which includes fixes for CVE-2022-41717,


### PR DESCRIPTION
- Update containerd to v1.6.12 to address CVE-2022-23471
