### PR TITLE
prepare release 1.6.15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.6.15-1) release; urgency=medium
+
+  * Update containerd to v1.6.15
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Mon, 09 Jan 2023 12:17:39 +0000
+
 containerd.io (1.6.14-1) release; urgency=medium
 
   * Update containerd to v1.6.14

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -162,6 +162,9 @@ done
 
 
 %changelog
+* Mon Jan 09 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.15-3.1
+- Update containerd to v1.6.15
+
 * Mon Dec 19 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.14-3.1
 - Update containerd to v1.6.14
 


### PR DESCRIPTION
update containerd binary to v1.6.15

release notes: https://github.com/containerd/containerd/releases/tag/v1.6.15

> Welcome to the v1.6.15 release of containerd!
>
> The fifteenth patch release for containerd 1.6 fixes an issue with CNI in the CRI plugin
>
> Notable Updates
>
> - Fix no CNI info for pod sandbox on restart in CRI plugin

full diff: https://github.com/containerd/containerd/compare/v1.6.14...v1.6.15
