### PR TITLE
Jenkinsfile: add Debian 12 "bookworm" (next stable)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,8 @@ def images = [
     [image: "quay.io/centos/centos:stream8",            arches: ["amd64", "aarch64"]],
     [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],
     [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
-    [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (Next stable)
+    [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (stable)
+    [image: "docker.io/library/debian:bookworm",        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (next stable)
     [image: "docker.io/library/fedora:36",              arches: ["amd64", "aarch64"]],          // EOL: May 24, 2023
     [image: "docker.io/library/fedora:37",              arches: ["amd64", "aarch64"]],          // EOL: TBD
     [image: "docker.io/library/fedora:38",              arches: ["amd64", "aarch64"]],          // EOL: TBD
@@ -19,6 +20,7 @@ def images = [
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
     [image: "docker.io/balenalib/rpi-raspbian:buster",  arches: ["armhf"]],
     [image: "docker.io/balenalib/rpi-raspbian:bullseye",arches: ["armhf"]],
+    [image: "docker.io/balenalib/rpi-raspbian:bookworm",arches: ["armhf"]],
     [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [image: "docker.io/library/ubuntu:jammy",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: April, 2027. EOL: April, 2032)


### PR DESCRIPTION
Not yet released, but freeze was announced;
https://lists.debian.org/debian-devel-announce/2023/01/msg00004.html
