### PR TITLE
prepare release 1.6.16

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.6.16-1) release; urgency=medium
+
+  * Update containerd to v1.6.16
+  * Update Golang runtime to 1.18.10
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Mon, 30 Jan 2023 08:39:50 +0000
+
 containerd.io (1.6.15-1) release; urgency=medium
 
   * Update containerd to v1.6.15

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -162,6 +162,10 @@ done
 
 
 %changelog
+* Mon Jan 30 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.16-3.1
+- Update containerd to v1.6.16
+- Update Golang runtime to 1.18.10
+
 * Mon Jan 09 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.15-3.1
 - Update containerd to v1.6.15
 


### PR DESCRIPTION
- update containerd binary to v1.6.16
- update Golang runtime to 1.18.10

release notes: https://github.com/containerd/containerd/releases/tag/v1.6.16

> - Fix push error propagation
> - Fix slice append error with HugepageLimits for Linux
> - Update default seccomp profile for PKU and CAP_SYS_NICE
> - Fix overlayfs error when upperdirlabel option is set

full diff: https://github.com/containerd/containerd/compare/v1.6.15...v1.6.16
