### PR TITLE
prepare release 1.6.18

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+containerd.io (1.6.18-1) release; urgency=high
+
+  * update containerd binary to v1.6.18, which includes fixes for CVE-2023-25153
+    and CVE-2023-25173.
+  * update Golang runtime to 1.19.6, which includes fixes for CVE-2022-41722,
+    CVE-2022-41725, CVE-2022-41724, and CVE-2022-41723.
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Thu, 16 Feb 2023 10:34:27 +0000
+
 containerd.io (1.6.17-1) release; urgency=medium
 
   * Update containerd to v1.6.17

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.6.17-1) release; urgency=medium
+
+  * Update containerd to v1.6.17
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Thu, 16 Feb 2023 10:27:26 +0000
+
 containerd.io (1.6.16-1) release; urgency=medium
 
   * Update containerd to v1.6.16

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -176,6 +176,12 @@ done
 
 
 %changelog
+* Thu Feb 16 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.18-3.1
+- update containerd binary to v1.6.18, which includes fixes for CVE-2023-25153
+  and CVE-2023-25173.
+- update Golang runtime to 1.19.6, which includes fixes for CVE-2022-41722,
+  CVE-2022-41725, CVE-2022-41724, and CVE-2022-41723.
+
 * Thu Feb 16 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.17-3.1
 - Update containerd to v1.6.17
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -176,6 +176,9 @@ done
 
 
 %changelog
+* Thu Feb 16 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.17-3.1
+- Update containerd to v1.6.17
+
 * Mon Jan 30 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.16-3.1
 - Update containerd to v1.6.16
 - Update Golang runtime to 1.18.10


### PR DESCRIPTION
### prepare release 1.6.18

- update containerd binary to v1.6.18, which includes fixes for CVE-2023-25153
  and CVE-2023-25173.
- update Golang runtime to 1.19.6, which includes fixes for CVE-2022-41722,
  CVE-2022-41725, CVE-2022-41724, and CVE-2022-41723.

release notes: https://github.com/containerd/containerd/releases/tag/v1.6.18

> - Fix OCI image importer memory exhaustion (GHSA-259w-8hf6-59c2)
> - Fix supplementary groups not being set up properly (GHSA-hmfx-3pcx-653p)
> - Revert removal of /sbin/apparmor_parser check
> - Update Go to 1.19.6

full diff: https://github.com/containerd/containerd/compare/v1.6.17...v1.6.18

### prepare release 1.6.17

- update containerd binary to v1.6.17

release notes: https://github.com/containerd/containerd/releases/tag/v1.6.17

> - Add network plugin metrics
> - Update mkdir permission on /etc/cni to 0755 instead of 0700
> - Export remote snapshotter label handler
> - Add support for default hosts.toml configuration

full diff: https://github.com/containerd/containerd/compare/v1.6.16...v1.6.17