### PR TITLE
rpm: add conditionals to disable btrfs for CentOS 7 on containerd 1.7 and up

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,6 +2,9 @@ Source: containerd.io
 Section: devel
 Priority: optional
 Maintainer: Containerd team <help@containerd.io>
+# btrfs dependencies no longer needed for containerd 1.7 and up, which now
+# uses the Linux kernel headers for this.
+# TODO(thaJeztah): remove btrfs build-dependencies once containerd 1.6 reaches EOL.
 Build-Depends: libbtrfs-dev | btrfs-tools ,
                debhelper (>= 10~) | dh-systemd,
                pkg-config,


### PR DESCRIPTION
- relates to https://github.com/docker/containerd-packaging/pull/308#issuecomment-1432957713
- relates to https://github.com/containerd/containerd/pull/7933


Containerd (and Moby) now use the Linux kernel headers for btrfs support. These headers are not available on CentOS 7, as support for btrfs was experimental, and now deprecated (removed), which causes builds of containerd main (and 1.7+) to fail:

    # github.com/containerd/btrfs/v2
    In file included from vendor/github.com/containerd/btrfs/v2/btrfs.go:21:0:
    ./btrfs.h:19:2: error: #error "Headers from kernel >= 4.12 are required on compilation time (not on run time)"
     #error "Headers from kernel >= 4.12 are required on compilation time (not on run time)"
      ^
    In file included from vendor/github.com/containerd/btrfs/v2/btrfs.go:21:0:
    ./btrfs.h:22:30: fatal error: linux/btrfs_tree.h: No such file or directory
     #include <linux/btrfs_tree.h>

Given that this feature was experimental, and no longer supported by the distro itself, we'll stop building btrfs for CentOS for containerd 1.7, but as the same scripts are used for both 1.6 (and older) and 1.7, we need to make this feature conditional so that 1.6.x continues to have it included.

Also added TODOs to remove the btrfs build-dependencies once containerd 1.6 reaches EOL (or once we stop building it).

To verify:

when building containerd 1.6, the btrfs dependencies are installed:

    make PROGRESS=plain REF=v1.6.18 docker.io/library/centos:7

    #28 2.281 Getting requirements for SPECS/containerd.spec

    #28 4.193 Dependencies Resolved
    #28 4.196
    #28 4.196 ================================================================================
    #28 4.196  Package                  Arch          Version               Repository   Size
    #28 4.196 ================================================================================
    #28 4.196 Installing:
    #28 4.196  btrfs-progs-devel        x86_64        4.9.1-1.el7           base         47 k
    #28 4.196 Installing for dependencies:
    #28 4.196  btrfs-progs              x86_64        4.9.1-1.el7           base        678 k
    ...
    #28 89.26 + BUILDTAGS=
    #28 89.26 + GO111MODULE=auto
    #28 89.26 + make -C /go/src/github.com/containerd/containerd VERSION=1.6.18 REVISION=2456e983eb9e37e47538f59ea18f2043c9a73640 PACKAGE=containerd.io BUILDTAGS=

when building containerd main (1.7), the dependencies are not installed, and containerd is built with the "no_btrfs" build-tag:

    make PROGRESS=plain REF=main docker.io/library/centos:7

    #28 2.495 Getting requirements for SPECS/containerd.spec
    ...
    #28 2.550 No uninstalled build requires
    ...
    #28 115.0 + BUILDTAGS=
    #28 115.0 + BUILDTAGS=' no_btrfs'
    #28 115.0 + GO111MODULE=auto
    #28 111.9 + make -C /go/src/github.com/containerd/containerd VERSION=0.20230216.040928~24cf85f REVISION=24cf85f5a3d1088bd6518f8ec86a32397feff213 PACKAGE=containerd.io 'BUILDTAGS= no_btrfs'

