### PR TITLE
prepare release 1.6.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.6.19-1) release; urgency=medium
+
+  * Update containerd to v1.6.19
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Wed, 22 Mar 2023 13:21:55 +0000
+
 containerd.io (1.6.18-1) release; urgency=high
 
   * update containerd binary to v1.6.18, which includes fixes for CVE-2023-25153

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -176,6 +176,9 @@ done
 
 
 %changelog
+* Wed Mar 22 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.19-3.1
+- Update containerd to v1.6.19
+
 * Thu Feb 16 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.18-3.1
 - update containerd binary to v1.6.18, which includes fixes for CVE-2023-25153
   and CVE-2023-25173.


### PR DESCRIPTION
Notable Updates

- Update hcsshim to v0.9.7 to include fix for graceful termination and pause containers