### PR TITLE
update changelog to include Go 1.19.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 containerd.io (1.6.19-1) release; urgency=medium
 
   * Update containerd to v1.6.19
+  * Update Golang runtime to 1.19.7
 
- -- Sebastiaan van Stijn <thajeztah@docker.com>  Wed, 22 Mar 2023 13:21:55 +0000
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Thu, 23 Mar 2023 13:58:39 +0000
 
 containerd.io (1.6.18-1) release; urgency=high
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -176,8 +176,9 @@ done
 
 
 %changelog
-* Wed Mar 22 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.19-3.1
+* Thu Mar 23 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.19-3.1
 - Update containerd to v1.6.19
+- Update Golang runtime to 1.19.7
 
 * Thu Feb 16 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.18-3.1
 - update containerd binary to v1.6.18, which includes fixes for CVE-2023-25153


### PR DESCRIPTION
While containerd upstream did not yet update the Go version to 1.19.7, we will be packaging with that version. go1.19.7 contains some security fixes. Those fixes may not affect these binaries, but may still trigger security scanners, so let's update the version.