### PR TITLE
remove Ubuntu 18.04 Bionic Beaver LTS, as it reached end of standard support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,6 @@ def images = [
     [image: "docker.io/balenalib/rpi-raspbian:buster",  arches: ["armhf"]],
     [image: "docker.io/balenalib/rpi-raspbian:bullseye",arches: ["armhf"]],
     [image: "docker.io/balenalib/rpi-raspbian:bookworm",arches: ["armhf"]],
-    [image: "docker.io/library/ubuntu:bionic",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [image: "docker.io/library/ubuntu:jammy",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: April, 2027. EOL: April, 2032)
     [image: "docker.io/library/ubuntu:kinetic",         arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.10 (EOL: July, 2023)

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endif
 
 # This targets allows building multiple distros at once, for example:
 #
-#     make docker.io/library/ubuntu:bionic docker.io/library/centos:7
+#     make docker.io/library/ubuntu:jammy docker.io/library/centos:7
 #     make quay.io/centos/centos:stream8
 #
 # It is a shorthand for "make BUILD_IMAGE=mydistro:version build"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ make docker.io/library/<distro>:<version> [docker.io/library/<distro>:<version> 
 
 # for example:
 # make docker.io/library/centos:7
-# make docker.io/library/ubuntu:bionic
+# make docker.io/library/ubuntu:jammy
 ```
 
 After build completes, packages can be found in the `build` directory.
@@ -28,7 +28,7 @@ For example:
 
 ```bash
 make clean
-make REF=HEAD CONTAINERD_DIR=/home/me/go/src/github.com/containerd/containerd docker.io/library/ubuntu:bionic
+make REF=HEAD CONTAINERD_DIR=/home/me/go/src/github.com/containerd/containerd docker.io/library/ubuntu:jammy
 ```
 
 ## For package maintainers:

--- a/debian/README.md
+++ b/debian/README.md
@@ -9,7 +9,7 @@ repository.
 Afterwards test if you can actually build the release with (for example):
 
 ```bash
-make REF=${TAG} docker.io/library/ubuntu:bionic
+make REF=${TAG} docker.io/library/ubuntu:jammy
 ```
 
 If you can actually build the package then start prepping
@@ -31,11 +31,11 @@ VERSION is already there.
 Releases can then be built with:
 
 ```bash
-make REF=${TAG} docker.io/library/ubuntu:bionic
+make REF=${TAG} docker.io/library/ubuntu:jammy
 ```
 
 or
 
 ```bash
-make REF=${TAG} BUILD_IMAGE=docker.io/library/ubuntu:bionic
+make REF=${TAG} BUILD_IMAGE=docker.io/library/ubuntu:jammy
 ```


### PR DESCRIPTION
Ubuntu 18.04 LTS reached end of standard support. Expanded Security Maintenance (ESM) is available, but requires a subscription, and we don't provide packages for those.

- https://wiki.ubuntu.com/Releases
- https://ubuntu.com//blog/18-04-end-of-standard-support