### PR TITLE
Jenkinsfile: add Rocky Linux and AlmaLinux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,14 +8,14 @@
 def images = [
     [image: "docker.io/library/amazonlinux:2",          arches: ["aarch64"]],
     [image: "docker.io/library/centos:7",               arches: ["amd64", "aarch64"]],
-    [image: "quay.io/centos/centos:stream8",            arches: ["amd64", "aarch64"]],
-    [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],
-    [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
-    [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (stable)
-    [image: "docker.io/library/debian:bookworm",        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (next stable)
-    [image: "docker.io/library/fedora:37",              arches: ["amd64", "aarch64"]],          // EOL: November 14, 2023
-    [image: "docker.io/library/fedora:38",              arches: ["amd64", "aarch64"]],          // EOL: May 14, 2024
-    [image: "docker.io/library/fedora:39",              arches: ["amd64", "aarch64"]],          // EOL: November 12, 2024
+    [image: "quay.io/centos/centos:stream8",            arches: ["amd64", "aarch64"]],          // CentOS Stream 8 (EOL: 2024-05-31)
+    [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],          // CentOS Stream 9 (EOL: 2027)
+    [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2022-09-10, EOL LTS: 2024-06-30)
+    [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (EOL: 2024)
+    [image: "docker.io/library/debian:bookworm",        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (stable)
+    [image: "docker.io/library/fedora:37",              arches: ["amd64", "aarch64"]],          // Fedora 37 (EOL: November 14, 2023)
+    [image: "docker.io/library/fedora:38",              arches: ["amd64", "aarch64"]],          // Fedora 38 (EOL: May 14, 2024)
+    [image: "docker.io/library/fedora:39",              arches: ["amd64", "aarch64"]],          // Fedora 39 (EOL: November 12, 2024)
     [image: "docker.io/library/fedora:rawhide",         arches: ["amd64", "aarch64"]],          // Rawhide is the name given to the current development version of Fedora
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
     [image: "docker.io/balenalib/rpi-raspbian:buster",  arches: ["armhf"]],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,10 @@ def images = [
     [image: "docker.io/library/centos:7",               arches: ["amd64", "aarch64"]],
     [image: "quay.io/centos/centos:stream8",            arches: ["amd64", "aarch64"]],          // CentOS Stream 8 (EOL: 2024-05-31)
     [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],          // CentOS Stream 9 (EOL: 2027)
+    [image: "docker.io/library/rockylinux:8",           arches: ["amd64", "aarch64"]],          // Rocky Linux 8 (EOL: 2029-05-31)
+    [image: "docker.io/library/rockylinux:9",           arches: ["amd64", "aarch64"]],          // Rocky Linux 9 (EOL: 2032-05-31)
+    [image: "docker.io/library/almalinux:8",            arches: ["amd64", "aarch64"]],          // AlmaLinux 8 (EOL: 2029)
+    [image: "docker.io/library/almalinux:9",            arches: ["amd64", "aarch64"]],          // AlmaLinux 9 (EOL: 2032)
     [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2022-09-10, EOL LTS: 2024-06-30)
     [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (EOL: 2024)
     [image: "docker.io/library/debian:bookworm",        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (stable)

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -47,6 +47,10 @@ FROM redhat-base AS ol-base
 RUN . "/etc/os-release"; if [ "${VERSION_ID%.*}" -eq 7 ]; then yum-config-manager --enable ol7_addons --enable ol7_optional_latest; fi
 RUN . "/etc/os-release"; if [ "${VERSION_ID%.*}" -eq 8 ]; then yum-config-manager --enable ol8_addons; fi
 
+FROM redhat-base AS rocky-base
+
+FROM redhat-base AS almalinux-base
+
 FROM ${BUILD_IMAGE} AS fedora-base
 RUN dnf install -y rpm-build git dnf-plugins-core
 


### PR DESCRIPTION
CentOS Stream 8 will reach its EOL within less than a year ahead of Rocky and Alma:

- CentOS Stream 8: 2024-05-31
- Rocky Linux 8: 2029-05-31
- AlmaLinux 8: 2029

So RPMs for Rocky and Alma have to be built without depending on CentOS Stream.

Part of :
- docker/docker-ce-packaging#933