### PR TITLE
Jenkinsfile: remove s390x left-overs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,9 +43,7 @@ def generatePackageStep(opts, arch) {
                     '''
                     checkout scm
                     sh 'make clean'
-                    withDockerRegistry([url: "", credentialsId: "dockerbuildbot-index.docker.io"]) {
-                        sh "make CREATE_ARCHIVE=1 ${opts.image}"
-                    }
+                    sh "make CREATE_ARCHIVE=1 ${opts.image}"
                     archiveArtifacts(artifacts: 'archive/*.tar.gz', onlyIfSuccessful: true)
                 } finally {
                     deleteDir()


### PR DESCRIPTION
- follow-up to https://github.com/docker/containerd-packaging/pull/260
- related to https://github.com/docker/containerd-packaging/pull/167

This was added in a80d978479f989f1daafcae9eef94903adce7c7c, because RHEL builds for s390x used a private image on Docker Hub. The s390x builds were disabled, and removed in ff03b26d4f75d1a1cd84f0c4bf6c3f9a7f78b081, so this is no longer needed.