### PR TITLE
prepare release 1.6.28

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.6.28-1) release; urgency=high
+
+  * update containerd binary to v1.6.28.
+  * update runc binary to v1.1.12, which includes fixes for CVE-2024-21626.
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Wed, 31 Jan 2024 11:02:21 +0000
+
 containerd.io (1.6.27-1) release; urgency=medium
 
   * update containerd binary to v1.6.27

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -176,7 +176,11 @@ done
 
 
 %changelog
-* Fri Jan 12 2024 Sebastiaan van Stijn <thajeztah@docker.coml> - 1.6.27-3.1
+* Wed Jan 31 2024 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.28-3.1
+- update containerd binary to v1.6.28.
+- update runc binary to v1.1.12, which includes fixes for CVE-2024-21626.
+
+* Fri Jan 12 2024 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.27-3.1
 - update containerd binary to v1.6.27
 - update runc binary to v1.1.11
 - Update Golang runtime to 1.20.13


### PR DESCRIPTION
- update containerd binary to v1.6.28.
- update runc binary to v1.1.12, which includes fixes for CVE-2024-21626.