### PR TITLE
[main] RHEL PoC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,14 +47,14 @@ def generatePackageStep(opts, arch) {
                 sh 'make clean'
             }
             stage("build") {
-                sh "make CREATE_ARCHIVE=1 ${opts.image}"
+                sh "make CREATE_ARCHIVE=1 ARCH=${arch} ${opts.image}"
                 archiveArtifacts(artifacts: 'archive/*.tar.gz', onlyIfSuccessful: true)
             }
             stage("build-main") {
                 // We're not archiving these builds as they have the same name
                 // as the 1.7 builds, so would replace those. We're building
                 // the main branch to verify that the scripts work for main (2.0)
-                sh "make REF=main ${opts.image}"
+                sh "make REF=main ARCH=${arch} ${opts.image}"
             }
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ endif
 #     make quay.io/centos/centos:stream8
 #
 # It is a shorthand for "make BUILD_IMAGE=mydistro:version build"
-.PHONY: docker.io/% quay.io/%
-docker.io/% quay.io/%:
+.PHONY: docker.io/% quay.io/% registry.access.redhat.com/%
+docker.io/% quay.io/% registry.access.redhat.com/%:
 	$(MAKE) BUILD_IMAGE="$@" build
 
 .PHONY: checkout
@@ -97,6 +97,8 @@ build:
 
 	@set -x; DOCKER_BUILDKIT=1 docker build \
 		--pull \
+		--build-arg RH_USER=$(RH_USER) \
+		--build-arg RH_PASS=$(RH_PASS) \
 		--platform linux/$(ARCH) \
 		--build-arg GOLANG_IMAGE="$(GOLANG_IMAGE)" \
 		--build-arg BUILD_IMAGE="$(BUILD_IMAGE)" \

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 include common/common.mk
 
+ARCH=$(shell uname -m)
 BUILD_IMAGE=ubuntu:focal
 BUILD_TYPE=$(shell ./scripts/deb-or-rpm $(BUILD_IMAGE))
 BUILD_BASE=$(shell ./scripts/determine-base $(BUILD_IMAGE))
@@ -84,7 +85,7 @@ build:
 	@echo ""
 	@echo "containerd   : $(REF) (commit: $(shell git -C "src/github.com/containerd/containerd" log -1 --pretty='%h'))"
 	@echo "runc         : $$(./scripts/determine-runc-version) (commit: $$(git -C "src/github.com/opencontainers/runc" log -1 --pretty='%h'))"
-	@echo "architecture : $(shell uname -m)"
+	@echo "architecture : $(ARCH)"
 	@echo "build image  : $(BUILD_IMAGE)"
 	@echo "golang image : $(GOLANG_IMAGE)"
 	@echo "--------------------------------------------------------------------"
@@ -96,6 +97,7 @@ build:
 
 	@set -x; DOCKER_BUILDKIT=1 docker build \
 		--pull \
+		--platform linux/$(ARCH) \
 		--build-arg GOLANG_IMAGE="$(GOLANG_IMAGE)" \
 		--build-arg BUILD_IMAGE="$(BUILD_IMAGE)" \
 		--build-arg BASE="$(BUILD_BASE)" \

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -32,6 +32,11 @@ FROM ${BUILD_IMAGE} AS redhat-base
 RUN dnf install -y rpm-build git dnf-plugins-core
 
 FROM redhat-base AS rhel-base
+ARG RH_USER
+ARG RH_PASS
+RUN rm /etc/rhsm-host 
+RUN subscription-manager register --username=$RH_USER --password=$RH_PASS
+RUN subscription-manager repos --enable codeready-builder-for-rhel-$(source /etc/os-release && echo "${VERSION_ID%.*}")-$(arch)-rpms
 
 FROM redhat-base AS centos-base
 RUN dnf config-manager --set-enabled crb


### PR DESCRIPTION
This is a PoC for building RHEL packages assuming that a RHEL username/password is available in the environment.

This is mostly intended for internal use by Docker, as it is assumed that the main utility is performing builds with a 'real RHEL' for enterprise customers. As such, there is currently no verification in this upstream repository.

However, when a unencumbered RHEL-equivalent distribution (e.g. Rocky) is supported, it will make sense to add verification for that distribution and generalize the 'rhel' infrastructure in this repo.