### PR TITLE
Add Ubuntu 24.04 Noble (not released yet).

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ def images = [
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [image: "docker.io/library/ubuntu:jammy",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: April, 2027. EOL: April, 2032)
     [image: "docker.io/library/ubuntu:mantic",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 23.10 (EOL: July, 2024)
+    [image: "docker.io/library/ubuntu:noble",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.04 LTS (End of support: April, 2029. EOL: April, 2034)
 ]
 
 def generatePackageStep(opts, arch) {


### PR DESCRIPTION
- carrying the Ubuntu part of https://github.com/docker/containerd-packaging/pull/330
- closes https://github.com/docker/containerd-packaging/pull/330