### PR TITLE
debian: add explicit GOARM for raspbian

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+# FIXME: quick hardcoding of GOARM for raspbian; replace with a holistic
+# refactoring of how we handle target architecture
+distribution := $(shell . /etc/os-release; echo "$${ID}")
+ifeq ($(distribution),raspbian)
+	export GOARM=6
+endif
+
+
 %:
 	dh $@ --with systemd
 


### PR DESCRIPTION
This is a quick band-aid; we need to overhaul how we handle architectures in these scripts (and use the Debian base images for Raspbian); but for now this should ensure we force ARMv6 for Raspbian targets.