### PR TITLE
prepare release 1.6.28-2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,3 @@
-containerd.io (1.6.30-1) release; urgency=medium
-
-  * update containerd binary to v1.6.30
-  * Update Golang runtime to 1.21.8
-
- -- Sebastiaan van Stijn <thajeztah@docker.com>  Wed, 13 Mar 2024 09:14:23 +0000
-
 containerd.io (1.6.28-1) release; urgency=high
 
   * update containerd binary to v1.6.28.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+containerd.io (1.6.28-2) release; urgency=medium
+
+  * Fix builds for Raspbian armhf producing armv7 binaries
+  * Build Debian armhf binaries as armv6
+  * Update Golang runtime to 1.21.8
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Fri, 15 Mar 2024 14:41:52 +0000
+
 containerd.io (1.6.28-1) release; urgency=high
 
   * update containerd binary to v1.6.28.

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -176,6 +176,9 @@ done
 
 
 %changelog
+* Fri Mar 15 2024 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.28-3.2
+- Update Golang runtime to 1.21.8
+
 * Wed Jan 31 2024 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.28-3.1
 - update containerd binary to v1.6.28.
 - update runc binary to v1.1.12, which includes fixes for CVE-2024-21626.

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -176,10 +176,6 @@ done
 
 
 %changelog
-* Wed Mar 13 2024 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.30-3.1
-- update containerd binary to v1.6.30
-- Update Golang runtime to 1.21.8
-
 * Wed Jan 31 2024 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.28-3.1
 - update containerd binary to v1.6.28.
 - update runc binary to v1.1.12, which includes fixes for CVE-2024-21626.


### PR DESCRIPTION
- relates to https://github.com/docker/containerd-packaging/issues/346
- temporarily reverts https://github.com/docker/containerd-packaging/pull/347
- Fix builds for Raspbian armhf producing armv7 binaries
- Build Debian armhf binaries as armv6
- Update Golang runtime to 1.21.8
