### PR TITLE
prepare release 1.6.31

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.6.31-1) release; urgency=medium
+
+  * update containerd binary to v1.6.31
+  * Update Golang runtime to 1.21.9
+
+ -- Paweł Gronowski <pawel.gronowski@docker.com>  Wed, 10 Apr 2024 12:46:52 +0000
+
 containerd.io (1.6.28-2) release; urgency=medium
 
   * Fix builds for Raspbian armhf producing armv7 binaries

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -176,6 +176,10 @@ done
 
 
 %changelog
+* Wed Apr 10 2024 Paweł Gronowski <pawel.gronowski@docker.com> - 1.6.31-3.1
+- update containerd binary to v1.6.31
+- Update Golang runtime to 1.21.9
+
 * Fri Mar 15 2024 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.28-3.2
 - Update Golang runtime to 1.21.8
 


### PR DESCRIPTION
- update containerd binary to v1.6.31
- Update Golang runtime to 1.21.9

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>