### PR TITLE
[main] CI: build both release/1.7 and main branches

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -16,7 +16,7 @@
 #       GOVERSION, as it's hardcoded to look in the upstream repository
 CONTAINERD_REMOTE ?=https://github.com/containerd/containerd.git
 RUNC_REMOTE       ?=https://github.com/opencontainers/runc.git
-REF?=HEAD
+REF?=release/1.7
 
 # Select the default version of Golang and runc based on the containerd source.
 GOLANG_VERSION?=$(shell grep "ARG GOLANG_VERSION" src/github.com/containerd/containerd/contrib/Dockerfile.test | awk -F'=' '{print $$2}')


### PR DESCRIPTION
Try building both the current (v1.7) and main (v2.0) branches.

We currently package 1.7, but use CI in this repository to also verify if the main (2.0) branch builds succesfully using the scripts in this repository.


**- A picture of a cute animal (not mandatory but encouraged)**

