### PR TITLE
README: fix missing value for RUNC_REF in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following example builds packages for containerd v1.7.18 with
 runc v1.1.12 for Ubuntu 24.04:
 
 ```bash
-make REF=v1.7.18 RUNC_REF= docker.io/library/ubuntu:24.04
+make REF=v1.7.18 RUNC_REF=v1.1.12 docker.io/library/ubuntu:24.04
 ```
 
 ## Building a package from a local source directory


### PR DESCRIPTION
looks like this was missed in 0737507e1ed78267c5964a64d8afd7a30b1a55fb (https://github.com/docker/containerd-packaging/pull/361) 🙈 


**- A picture of a cute animal (not mandatory but encouraged)**

