### PR TITLE
[main] Makefile: set default branch when initializing git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ src/github.com/opencontainers/runc:
 	cp -r "$(RUNC_DIR)" $@
 else
 src/github.com/opencontainers/runc:
-	git init $@
+	git init --initial-branch=main $@
 	git -C $@ remote add origin "$(RUNC_REMOTE)"
 endif
 
@@ -57,7 +57,7 @@ src/github.com/containerd/containerd:
 	cp -r "$(CONTAINERD_DIR)" $@
 else
 src/github.com/containerd/containerd:
-	git init $@
+	git init --initial-branch=main $@
 	git -C $@ remote add origin "$(CONTAINERD_REMOTE)"
 endif
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -22,7 +22,7 @@ src/github.com/containerd/containerd:
 	Xcopy /E /I "$(CONTAINERD_DIR)" $@
 else
 src/github.com/containerd/containerd:
-	git init $@
+	git init --initial-branch=main $@
 	git -C $@ remote add origin "$(CONTAINERD_REMOTE)"
 endif
 


### PR DESCRIPTION
This should suppress these hints printed during build:

    hint: Using 'master' as the name for the initial branch. This default branch name
    hint: is subject to change. To configure the initial branch name to use in all
    hint: of your new repositories, which will suppress this warning, call:
    hint:
    hint: 	git config --global init.defaultBranch <name>
    hint:
    hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
    hint: 'development'. The just-created branch can be renamed via this command:
    hint:
    hint: 	git branch -m <name>


**- A picture of a cute animal (not mandatory but encouraged)**

