### PR TITLE
[main] Revert "Jenkinsfile: temporarily disable Fedora Rawhide"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,7 @@ def images = [
     [image: "docker.io/library/debian:bookworm",        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (stable)
     [image: "docker.io/library/fedora:39",              arches: ["amd64", "aarch64"]],          // Fedora 39 (EOL: November 12, 2024)
     [image: "docker.io/library/fedora:40",              arches: ["amd64", "aarch64"]],          // Fedora 40 (EOL: May 13, 2025)
-// FIXME(thaJeztah): temporarily disabled; see https://github.com/docker/runtime-team/issues/140 and https://github.com/docker/containerd-packaging/pull/354#issuecomment-2148423969
-//     [image: "docker.io/library/fedora:rawhide",         arches: ["amd64", "aarch64"]],          // Rawhide is the name given to the current development version of Fedora
+    [image: "docker.io/library/fedora:rawhide",         arches: ["amd64", "aarch64"]],          // Rawhide is the name given to the current development version of Fedora
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
     [image: "docker.io/balenalib/rpi-raspbian:bullseye",arches: ["armhf"]],
     [image: "docker.io/balenalib/rpi-raspbian:bookworm",arches: ["armhf"]],


### PR DESCRIPTION
- reverts https://github.com/docker/containerd-packaging/pull/368
- (internal tracking ticket); https://github.com/docker/runtime-team/issues/140 

This reverts commit c1625f75251d1b85ecef1d497ae47cc3a83ee719.



**- A picture of a cute animal (not mandatory but encouraged)**

