### PR TITLE
[main] Jenkinsfile: remove CentOS 7 (EOL 2024-06-30)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@
 // When adding a distro here, also open a pull request in the release repository.
 def images = [
     [image: "docker.io/library/amazonlinux:2",          arches: ["aarch64"]],
-    [image: "docker.io/library/centos:7",               arches: ["amd64", "aarch64"]],
     [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],          // CentOS Stream 9 (EOL: 2027)
     [image: "docker.io/library/rockylinux:8",           arches: ["amd64", "aarch64"]],          // Rocky Linux 8 (EOL: 2029-05-31)
     [image: "docker.io/library/rockylinux:9",           arches: ["amd64", "aarch64"]],          // Rocky Linux 9 (EOL: 2032-05-31)


### PR DESCRIPTION
CentOS 7 [reaches EOL on June 30][1], so we won't be building packages for containerd 1.7. containerd 1.6 packages are still available for the remaining time for those that need it.

This patch removes it from CI in this repository (but could still be built in our release pipeline).

[1]: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/#centos-linux-7-end-of-life-june-30-2024


**- A picture of a cute animal (not mandatory but encouraged)**

