### PR TITLE
prepare release 1.7.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.7.19-1) release; urgency=medium
+
+  * Update containerd binary to v1.7.19
+  * Update Golang runtime to 1.21.12, which includes a fix for CVE-2024-24791.
+
+ -- Sebastiaan van Stijn <thajeztah@docker.com>  Tue, 16 Jul 2024 21:05:17 +0000
+
 containerd.io (1.7.18-1) release; urgency=medium
 
   * Update containerd binary to v1.7.18

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -158,6 +158,10 @@ done
 
 
 %changelog
+* Tue Jul 16 2024 Sebastiaan van Stijn <thajeztah@docker.com> - 1.7.19-3.1
+- Update containerd binary to v1.7.19
+- Update Golang runtime to 1.21.12, which includes a fix for CVE-2024-24791.
+
 * Tue Jun 18 2024 Sebastiaan van Stijn <thajeztah@docker.com> - 1.7.18-3.1
 - Update containerd binary to v1.7.18
 - Update runc binary to v1.1.13


### PR DESCRIPTION
- Update containerd binary to v1.7.19
- Update Golang runtime to 1.21.12, which includes a fix for CVE-2024-24791.


**- A picture of a cute animal (not mandatory but encouraged)**

