### PR TITLE
[release/1.6 backport] Jenkinsfile: remove CentOS 7, Fedora 38, Debian and Raspbian 10 Buster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,13 +13,11 @@ def images = [
     [image: "docker.io/library/rockylinux:9",           arches: ["amd64", "aarch64"]],          // Rocky Linux 9 (EOL: 2032-05-31)
     [image: "docker.io/library/almalinux:8",            arches: ["amd64", "aarch64"]],          // AlmaLinux 8 (EOL: 2029)
     [image: "docker.io/library/almalinux:9",            arches: ["amd64", "aarch64"]],          // AlmaLinux 9 (EOL: 2032)
-    [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2022-09-10, EOL LTS: 2024-06-30)
     [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (EOL: 2024)
     [image: "docker.io/library/debian:bookworm",        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (stable)
     [image: "docker.io/library/fedora:39",              arches: ["amd64", "aarch64"]],          // Fedora 39 (EOL: November 12, 2024)
     [image: "docker.io/library/fedora:40",              arches: ["amd64", "aarch64"]],          // Fedora 40 (EOL: May 13, 2025)
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
-    [image: "docker.io/balenalib/rpi-raspbian:buster",  arches: ["armhf"]],
     [image: "docker.io/balenalib/rpi-raspbian:bullseye",arches: ["armhf"]],
     [image: "docker.io/balenalib/rpi-raspbian:bookworm",arches: ["armhf"]],
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@
 // When adding a distro here, also open a pull request in the release repository.
 def images = [
     [image: "docker.io/library/amazonlinux:2",          arches: ["aarch64"]],
-    [image: "docker.io/library/centos:7",               arches: ["amd64", "aarch64"]],
     [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],          // CentOS Stream 9 (EOL: 2027)
     [image: "docker.io/library/rockylinux:8",           arches: ["amd64", "aarch64"]],          // Rocky Linux 8 (EOL: 2029-05-31)
     [image: "docker.io/library/rockylinux:9",           arches: ["amd64", "aarch64"]],          // Rocky Linux 9 (EOL: 2032-05-31)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@ def images = [
     [image: "docker.io/library/debian:buster",          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2022-09-10, EOL LTS: 2024-06-30)
     [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (EOL: 2024)
     [image: "docker.io/library/debian:bookworm",        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (stable)
-    [image: "docker.io/library/fedora:38",              arches: ["amd64", "aarch64"]],          // Fedora 38 (EOL: May 14, 2024)
     [image: "docker.io/library/fedora:39",              arches: ["amd64", "aarch64"]],          // Fedora 39 (EOL: November 12, 2024)
     [image: "docker.io/library/fedora:40",              arches: ["amd64", "aarch64"]],          // Fedora 40 (EOL: May 13, 2025)
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],


### PR DESCRIPTION
backports:

- https://github.com/docker/containerd-packaging/pull/362
- https://github.com/docker/containerd-packaging/pull/370
- https://github.com/docker/containerd-packaging/pull/372