### PR TITLE
[main] rpm: drop fallbacks for CentOS/RHEL 7, use dnf instead of yum

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG BUILD_IMAGE=centos:7
+ARG BUILD_IMAGE=quay.io/centos/centos:stream9
 ARG BASE=centos
 ARG GOLANG_IMAGE=golang:latest
 
@@ -29,29 +29,24 @@ ARG MD2MAN_VERSION=v2.0.1
 RUN go install github.com/cpuguy83/go-md2man/v2@${MD2MAN_VERSION}
 
 FROM ${BUILD_IMAGE} AS redhat-base
-RUN yum install -y yum-utils rpm-build git
+RUN dnf install -y rpm-build git dnf-plugins-core
 
 FROM redhat-base AS rhel-base
 
 FROM redhat-base AS centos-base
-# Using a wildcard: CentOS 7 uses "CentOS-RepoName", CentOS 8 uses "CentOS-Linux-RepoName"
-RUN if [ -f /etc/yum.repos.d/CentOS-*PowerTools.repo ]; then sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-*PowerTools.repo; fi
-# In aarch64 (arm64) images, the altarch repo is specified as repository, but
-# failing, so replace the URL.
-RUN if [ -f /etc/yum.repos.d/CentOS-*Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-*Sources.repo; fi
-
-FROM redhat-base AS amzn-base
+RUN dnf config-manager --set-enabled crb
 
 FROM redhat-base AS ol-base
-RUN . "/etc/os-release"; if [ "${VERSION_ID%.*}" -eq 7 ]; then yum-config-manager --enable ol7_addons --enable ol7_optional_latest; fi
-RUN . "/etc/os-release"; if [ "${VERSION_ID%.*}" -eq 8 ]; then yum-config-manager --enable ol8_addons; fi
+RUN dnf config-manager --set-enabled ol8_addons
 
 FROM redhat-base AS rocky-base
 
 FROM redhat-base AS almalinux-base
 
-FROM ${BUILD_IMAGE} AS fedora-base
-RUN dnf install -y rpm-build git dnf-plugins-core
+FROM redhat-base AS fedora-base
+
+FROM ${BUILD_IMAGE} AS amzn-base
+RUN yum install -y yum-utils rpm-build git
 
 FROM ${BUILD_IMAGE} AS suse-base
 # On older versions of Docker the path may not be explicitly set

--- a/scripts/.rpm-helpers
+++ b/scripts/.rpm-helpers
@@ -51,21 +51,21 @@ install_build_deps() (
 	export RPM_VERSION="${RPM_VERSION:=0.0.1}"
 	export RPM_RELEASE_VERSION="${RPM_RELEASE_VERSION:=dev}"
 
-	if type yum-builddep >/dev/null 2>/dev/null; then
-		# shellcheck disable=SC2086
-		yum-builddep -y ${EXTRA_REPOS} "${SPEC_FILE}"
-	elif type dnf >/dev/null 2>/dev/null; then
+	if type dnf >/dev/null 2>/dev/null; then
 		# shellcheck disable=SC2086
 		dnf builddep -y ${EXTRA_REPOS} "${SPEC_FILE}"
+	elif type yum-builddep >/dev/null 2>/dev/null; then
+		# shellcheck disable=SC2086
+		yum-builddep -y ${EXTRA_REPOS} "${SPEC_FILE}"
 	else
-		# either yum-utils is not installed, or we're running on SUSE/openSuSE.
+		# either dnf core-utils is not installed, or we're running on SUSE/openSuSE.
 		# Zypper does not have a proper equivalent for installing build dependencies.
 		#
 		# This manual approach does an attempt to install dependencies
-		if type yum >/dev/null 2>/dev/null; then
-			pkg_manager="yum -y ${EXTRA_REPOS}"
-		elif type zypper >/dev/null 2>/dev/null; then
+		if type zypper >/dev/null 2>/dev/null; then
 			pkg_manager="zypper -n ${EXTRA_REPOS}"
+		elif type yum >/dev/null 2>/dev/null; then
+			pkg_manager="yum -y ${EXTRA_REPOS}"
 		else
 			echo "unable to detect package manager";
 			exit 1;
@@ -76,10 +76,10 @@ install_build_deps() (
 )
 
 install_package() (
-	if type yum >/dev/null 2>/dev/null; then
-		pkg_manager="yum -y"
-	elif type dnf >/dev/null 2>/dev/null; then
+	if type dnf >/dev/null 2>/dev/null; then
 		pkg_manager="dnf -y"
+	elif type yum >/dev/null 2>/dev/null; then
+		pkg_manager="yum -y"
 	elif type zypper >/dev/null 2>/dev/null; then
 		pkg_manager="zypper -n"
 	else


### PR DESCRIPTION
### scripts/.rpm-helpers: prioritize dnf over yum

dnf is the default for current RPM-based distros now, so moving it
as first choice. We can probably remove the fallback to yum, but
leaving that for a follow-up.

### Dockerfile.rpm: default to centos:stream9 and dnf

The Dockerfile was still defaulting to use CentOS 7, which is now EOL,
so using CentOS Stream 9 as default.

Also removing code related to old CentOS versions, and switching to
dnf as default.
