### PR TITLE
[main] rpm: rpm.Dockerfile: cleanup opensuse stage

### DIFF
--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -54,10 +54,7 @@ FROM ${BUILD_IMAGE} AS fedora-base
 RUN dnf install -y rpm-build git dnf-plugins-core
 
 FROM ${BUILD_IMAGE} AS suse-base
-# On older versions of Docker the path may not be explicitly set
-# opensuse also does not set a default path in their docker images
 RUN zypper -n install rpm-build git
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}
 RUN echo "%_topdir    /root/rpmbuild" > /root/.rpmmacros
 
 FROM ${BASE}-base AS distro-image

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -55,6 +55,12 @@ RUN dnf install -y rpm-build git dnf-plugins-core
 
 FROM ${BUILD_IMAGE} AS suse-base
 RUN zypper -n install rpm-build git
+
+# Align the rpm directories used with other rpm-distros.
+#
+# CentOS, RHEL, and Fedora all use "~/rpmbuild" ("/root/rpmbuild") as default,
+# but SUSE uses "/usr/src/packages". Align the directory so that we can keep
+# our scripts universal.
 RUN echo "%_topdir    /root/rpmbuild" > /root/.rpmmacros
 
 FROM ${BASE}-base AS distro-image


### PR DESCRIPTION
- relates to https://github.com/docker/containerd-packaging/pull/75

### rpm.Dockerfile: remove manual setting PATH for opensuse, SLES

This was added as part of 241608f9e17c8c0f3dba2f73b12275a3025ccc39, but
any version of docker (or BuildKit) should be setting the default PATH,
so setting it manually shouldn't be needed

```bash
docker run --rm docker.io/opensuse/leap:15 sh -c 'echo $PATH'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

### rpm.Dockerfile: add comment for custom rpm-macro on opensuse, SLES

This step did not have a comment describing why we're setting a custom macro.
CentOS, RHEL, and Fedora all use "~/rpmbuild" ("/root/rpmbuild") as default,
but SUSE uses "/usr/src/packages";

```bash
rpm --eval '%{_topdir}'
# /usr/src/packages

rpm --eval '%{_rpmdir}'
# /usr/src/packages/RPMS
```

The custom macro align the directory so that we can keep our scripts and
Dockerfile universal;

```bash
echo "%_topdir    /root/rpmbuild" > /root/.rpmmacros

rpm --eval '%{_topdir}'
# /root/rpmbuild

rpm --eval '%{_rpmdir}'
# /root/rpmbuild/RPMS
```
