### PR TITLE
[main] rpm: minimal RHEL support (carry #342)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,14 +47,14 @@ def generatePackageStep(opts, arch) {
                 sh 'make clean'
             }
             stage("build") {
-                sh "make CREATE_ARCHIVE=1 ${opts.image}"
+                sh "make CREATE_ARCHIVE=1 ARCH=${arch} ${opts.image}"
                 archiveArtifacts(artifacts: 'archive/*.tar.gz', onlyIfSuccessful: true)
             }
             stage("build-main") {
                 // We're not archiving these builds as they have the same name
                 // as the 1.7 builds, so would replace those. We're building
                 // the main branch to verify that the scripts work for main (2.0)
-                sh "make REF=main ${opts.image}"
+                sh "make REF=main ARCH=${arch} ${opts.image}"
             }
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,8 @@ build:
 
 	@set -x; DOCKER_BUILDKIT=1 docker build \
 		--pull \
+		--secret id=rh-user,env=RH_USER \
+		--secret id=rh-pass,env=RH_PASS \
 		--platform linux/$(ARCH) \
 		--build-arg GOLANG_IMAGE="$(GOLANG_IMAGE)" \
 		--build-arg BUILD_IMAGE="$(BUILD_IMAGE)" \

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 include common/common.mk
 
+ARCH=$(shell uname -m)
 BUILD_IMAGE=ubuntu:focal
 BUILD_TYPE=$(shell ./scripts/deb-or-rpm $(BUILD_IMAGE))
 BUILD_BASE=$(shell ./scripts/determine-base $(BUILD_IMAGE))
@@ -84,7 +85,7 @@ build:
 	@echo ""
 	@echo "containerd   : $(REF) (commit: $(shell git -C "src/github.com/containerd/containerd" log -1 --pretty='%h'))"
 	@echo "runc         : $$(./scripts/determine-runc-version) (commit: $$(git -C "src/github.com/opencontainers/runc" log -1 --pretty='%h'))"
-	@echo "architecture : $(shell uname -m)"
+	@echo "architecture : $(ARCH)"
 	@echo "build image  : $(BUILD_IMAGE)"
 	@echo "golang image : $(GOLANG_IMAGE)"
 	@echo "--------------------------------------------------------------------"
@@ -96,6 +97,7 @@ build:
 
 	@set -x; DOCKER_BUILDKIT=1 docker build \
 		--pull \
+		--platform linux/$(ARCH) \
 		--build-arg GOLANG_IMAGE="$(GOLANG_IMAGE)" \
 		--build-arg BUILD_IMAGE="$(BUILD_IMAGE)" \
 		--build-arg BASE="$(BUILD_BASE)" \

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -32,6 +32,19 @@ FROM ${BUILD_IMAGE} AS redhat-base
 RUN dnf install -y rpm-build git dnf-plugins-core
 
 FROM redhat-base AS rhel-base
+RUN --mount=type=secret,id=rh-user --mount=type=secret,id=rh-pass <<-EOT
+	rm -f /etc/rhsm-host
+
+	if [ ! -f /run/secrets/rh-user ] || [ ! -f /run/secrets/rh-pass ]; then
+		echo "Either RH_USER or RH_PASS is not set. Running build without subscription."
+	else
+		subscription-manager register \
+			--username="$(cat /run/secrets/rh-user)" \
+			--password="$(cat /run/secrets/rh-pass)"
+
+		subscription-manager repos --enable codeready-builder-for-rhel-$(source /etc/os-release && echo "${VERSION_ID%.*}"-$(arch)-rpms)
+	fi
+EOT
 
 FROM redhat-base AS centos-base
 RUN dnf config-manager --set-enabled crb


### PR DESCRIPTION
- carries https://github.com/docker/containerd-packaging/pull/342
- closes https://github.com/docker/containerd-packaging/pull/342


Implements passing the username and password through build-secrets instead of build-args

---


> This is a PoC for building RHEL packages assuming that a RHEL username/password is available in the environment.
>
> This is mostly intended for internal use by Docker, as it is assumed that the main utility is performing builds with a 'real RHEL' for enterprise customers. As such, there is currently no verification in this upstream repository.
>
> However, when a unencumbered RHEL-equivalent distribution (e.g. Rocky) is supported, it will make sense to add verification for that distribution and generalize the 'rhel' infrastructure in this repo.