### PR TITLE
[main] remove Ubuntu 23.10 (Mantic Minotaur) (EOL: July 11, 2024)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,6 @@ def images = [
     [image: "docker.io/balenalib/rpi-raspbian:bookworm",arches: ["armhf"]],
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [image: "docker.io/library/ubuntu:jammy",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: April, 2027. EOL: April, 2032)
-    [image: "docker.io/library/ubuntu:mantic",          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 23.10 (EOL: July, 2024)
     [image: "docker.io/library/ubuntu:noble",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.04 LTS (End of support: April, 2029. EOL: April, 2034)
 ]
 


### PR DESCRIPTION
Ubuntu 23.10 reached EOL on July 11, 2024: https://fridge.ubuntu.com/2024/07/17/ubuntu-23-10-mantic-minotaur-reached-end-of-life-on-july-11-2024/

