### PR TITLE
[main] deb, rpm: fix runc using incorrect version

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -44,7 +44,8 @@ binaries: ## Create containerd binaries
 	rm -f bin/containerd-stress
 
 bin/runc:
-	@set -x; make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
+	# Unset the VERSION variable as it's meant for containerd's version, not runc.
+	@set -x; env -u VERSION make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
 		BINDIR="$$(pwd)/bin" \
 		runc install
 

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -117,7 +117,8 @@ rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
 
-make -C /go/src/github.com/opencontainers/runc BINDIR=%{_builddir}/bin runc install
+# Unset the VERSION variable as it's meant for containerd's version, not runc.
+env -u VERSION make -C /go/src/github.com/opencontainers/runc BINDIR=%{_builddir}/bin runc install
 
 
 %install


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/pull/1044#issuecomment-2270858888
- relates to https://github.com/containerd/containerd/issues/10553
- relates to https://github.com/opencontainers/runc/pull/4270


runc v1.1.13 introduced an option to customize the version (as printed by the `--version` flag) through a `VERSION` Make variable / environment variable (see [1]).

This variable collided with the `VERSION` environment variable used by containerd for the same purpose, which lead to `runc` binaries built using the version of containerd;

    runc --version
    runc version 1.7.20
    commit: v1.1.13-0-g58aa9203
    ...

This patch explicitly sets the `VERSION` variable to the version of runc being built when building the binary.

[1]: https://github.com/opencontainers/runc/commit/6f4d975c402d7848f5097f53c18000aa42581def

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

