### PR TITLE
[release/1.6 backport] deb, rpm: fix runc using incorrect version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,30 @@ make clean
 make docker.io/library/<distro>:<version> [docker.io/library/<distro>:<version> ...]
 
 # for example:
-# make docker.io/library/centos:7
-# make docker.io/library/ubuntu:jammy
+# make quay.io/centos/centos:stream9
+# make docker.io/library/ubuntu:24.04
 ```
 
 After build completes, packages can be found in the `build` directory.
+
+## Specifying the version to build
+
+By default, packages are built from HEAD of the `release/1.7` branch, as
+defines in [common/common.mk]. The version of runc defaults to the version
+as specified by the containerd project through the [script/setup/runc-version]
+file in the containerd repository.
+
+Use the `REF` and `RUNC_REF` make variables to specify the versions to build.
+The provided values must be a valid Git reference, which can be a commit
+(e.g., `ae71819` or `ae71819c4f5e67bb4d5ae76a6b735f29cc25774e`), branch
+(e.g. `main` or `release/1.7`), or tag (e.g. `v1.7.18`).
+
+The following example builds packages for containerd v1.7.18 with
+runc v1.1.12 for Ubuntu 24.04:
+
+```bash
+make REF=v1.7.18 RUNC_REF= docker.io/library/ubuntu:24.04
+```
 
 ## Building a package from a local source directory
 
@@ -35,3 +54,7 @@ make REF=HEAD CONTAINERD_DIR=/home/me/go/src/github.com/containerd/containerd do
 
 * [deb package maintainers guide](debian/README.md)
 * [rpm package maintainers guide](rpm/README.md)
+
+
+[common/common.mk]: https://github.com/docker/containerd-packaging/blob/main/common/common.mk#L19
+[script/setup/runc-version]: https://github.com/containerd/containerd/blob/v1.7.18/script/setup/runc-version

--- a/debian/README.md
+++ b/debian/README.md
@@ -9,7 +9,7 @@ repository.
 Afterwards test if you can actually build the release with (for example):
 
 ```bash
-make REF=${TAG} docker.io/library/ubuntu:jammy
+make REF=${TAG} docker.io/library/ubuntu:24.04
 ```
 
 If you can actually build the package then start prepping
@@ -31,11 +31,11 @@ VERSION is already there.
 Releases can then be built with:
 
 ```bash
-make REF=${TAG} docker.io/library/ubuntu:jammy
+make REF=${TAG} docker.io/library/ubuntu:24.04
 ```
 
 or
 
 ```bash
-make REF=${TAG} BUILD_IMAGE=docker.io/library/ubuntu:jammy
+make REF=${TAG} BUILD_IMAGE=docker.io/library/ubuntu:24.04
 ```

--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,7 @@ Source: containerd.io
 Section: devel
 Priority: optional
 Maintainer: Containerd team <help@containerd.io>
-# btrfs dependencies no longer needed for containerd 1.7 and up, which now
-# uses the Linux kernel headers for this.
-# TODO(thaJeztah): remove btrfs build-dependencies once containerd 1.6 reaches EOL.
-Build-Depends: libbtrfs-dev | btrfs-tools ,
-               debhelper (>= 10~) | dh-systemd,
+Build-Depends: debhelper (>= 10~) | dh-systemd,
                pkg-config,
                libseccomp-dev
 Standards-Version: 4.1.4

--- a/debian/rules
+++ b/debian/rules
@@ -32,7 +32,7 @@ endif
 # TODO remove custom PREFIX variable once containerd release/1.4 and release/1.5
 #      are obsolete. See https://github.com/containerd/containerd/commit/b5f530a157
 binaries: ## Create containerd binaries
-	@set -x; GO111MODULE=auto make -C $(GO_SRC_PATH) --no-print-directory \
+	@set -x; make -C $(GO_SRC_PATH) --no-print-directory \
 		DESTDIR="$$(pwd)" \
 		PREFIX="" \
 		VERSION=$${VERSION} \
@@ -44,12 +44,12 @@ binaries: ## Create containerd binaries
 	rm -f bin/containerd-stress
 
 bin/runc:
-	@set -x; GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
+	@set -x; make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
 		BINDIR="$$(pwd)/bin" \
 		runc install
 
 man: ## Create containerd man pages
-	@set -x; GO111MODULE=auto make -C $(GO_SRC_PATH) --no-print-directory man
+	@set -x; make -C $(GO_SRC_PATH) --no-print-directory man
 
 	# copy the generated man pages instead of using "make install-man" to allow
 	# dh_installman doing its magic

--- a/debian/rules
+++ b/debian/rules
@@ -44,7 +44,8 @@ binaries: ## Create containerd binaries
 	rm -f bin/containerd-stress
 
 bin/runc:
-	@set -x; make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
+	# Unset the VERSION variable as it's meant for containerd's version, not runc.
+	@set -x; env -u VERSION make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
 		BINDIR="$$(pwd)/bin" \
 		runc install
 

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -24,7 +24,6 @@ FROM ${GOLANG_IMAGE} AS golang
 
 FROM golang AS go-md2man
 ARG GOPROXY=direct
-ENV GOTOOLCHAIN=local
 ARG MD2MAN_VERSION=v2.0.1
 RUN go install github.com/cpuguy83/go-md2man/v2@${MD2MAN_VERSION}
 

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -24,7 +24,6 @@ FROM ${GOLANG_IMAGE} AS golang
 
 FROM golang AS go-md2man
 ARG GOPROXY=direct
-ARG GO111MODULE=on
 ENV GOTOOLCHAIN=local
 ARG MD2MAN_VERSION=v2.0.1
 RUN go install github.com/cpuguy83/go-md2man/v2@${MD2MAN_VERSION}

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -25,7 +25,6 @@ FROM ${GOLANG_IMAGE} AS golang
 
 FROM golang AS go-md2man
 ARG GOPROXY=direct
-ENV GOTOOLCHAIN=local
 ARG MD2MAN_VERSION=v2.0.1
 RUN go install github.com/cpuguy83/go-md2man/v2@${MD2MAN_VERSION}
 

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -25,7 +25,6 @@ FROM ${GOLANG_IMAGE} AS golang
 
 FROM golang AS go-md2man
 ARG GOPROXY=direct
-ARG GO111MODULE=on
 ENV GOTOOLCHAIN=local
 ARG MD2MAN_VERSION=v2.0.1
 RUN go install github.com/cpuguy83/go-md2man/v2@${MD2MAN_VERSION}

--- a/dockerfiles/win.dockerfile
+++ b/dockerfiles/win.dockerfile
@@ -14,8 +14,7 @@
 
 ARG GOLANG_IMAGE=golang:latest
 FROM ${GOLANG_IMAGE} AS golang
-ENV GOTOOLCHAIN=local \
-    chocolateyUseWindowsCompression=false
+ENV chocolateyUseWindowsCompression=false
 # Install make and gcc
 # We install an older version of MinGW to workaround issues in CGO;
 # see https://github.com/golang/go/issues/51007

--- a/dockerfiles/win.dockerfile
+++ b/dockerfiles/win.dockerfile
@@ -14,9 +14,7 @@
 
 ARG GOLANG_IMAGE=golang:latest
 FROM ${GOLANG_IMAGE} AS golang
-ARG GO111MODULE=auto
-ENV GO111MODULE=$GO111MODULE \
-    GOTOOLCHAIN=local \
+ENV GOTOOLCHAIN=local \
     chocolateyUseWindowsCompression=false
 # Install make and gcc
 # We install an older version of MinGW to workaround issues in CGO;

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -9,7 +9,7 @@ repository.
 Afterwards test if you can actually build the release with (for example):
 
 ```bash
-make REF=${TAG} docker.io/library/centos:7
+make REF=${TAG} quay.io/centos/centos:stream9
 ```
 
 If you can actually build the package then start prepping
@@ -31,11 +31,11 @@ VERSION is already there.
 Releases can then be built with:
 
 ```bash
-make REF=${TAG} docker.io/library/centos:7
+make REF=${TAG} quay.io/centos/centos:stream9
 ```
 
 or
 
 ```bash
-make REF=${TAG} BUILD_IMAGE=docker.io/library/centos:7
+make REF=${TAG} BUILD_IMAGE=quay.io/centos/centos:stream9
 ```

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -117,7 +117,8 @@ rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
 
-make -C /go/src/github.com/opencontainers/runc BINDIR=%{_builddir}/bin runc install
+# Unset the VERSION variable as it's meant for containerd's version, not runc.
+env -u VERSION make -C /go/src/github.com/opencontainers/runc BINDIR=%{_builddir}/bin runc install
 
 
 %install

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -81,23 +81,23 @@ low-level storage and network attachments, etc.
 
 
 %prep
-rm -rf %{_topdir}/BUILD/
-if [ ! -d %{_topdir}/SOURCES/containerd ]; then
+rm -rf %{_builddir}
+if [ ! -d %{_sourcedir}/containerd ]; then
     # Copy over our source code from our gopath to our source directory
-    cp -rf /go/src/%{import_path} %{_topdir}/SOURCES/containerd;
+    cp -rf /go/src/%{import_path} %{_sourcedir}/containerd;
 fi
 # symlink the go source path to our build directory
-ln -s /go/src/%{import_path} %{_topdir}/BUILD
+ln -s /go/src/%{import_path} %{_builddir}
 
-if [ ! -d %{_topdir}/SOURCES/runc ]; then
+if [ ! -d %{_sourcedir}/runc ]; then
     # Copy over our source code from our gopath to our source directory
-    cp -rf /go/src/github.com/opencontainers/runc %{_topdir}/SOURCES/runc
+    cp -rf /go/src/github.com/opencontainers/runc %{_sourcedir}/runc
 fi
-cd %{_topdir}/BUILD/
+cd %{_builddir}
 
 
 %build
-cd %{_topdir}/BUILD
+cd %{_builddir}
 make man
 
 BUILDTAGS=""
@@ -117,11 +117,11 @@ rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
 
-make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin runc install
+make -C /go/src/github.com/opencontainers/runc BINDIR=%{_builddir}/bin runc install
 
 
 %install
-cd %{_topdir}/BUILD
+cd %{_builddir}
 mkdir -p %{buildroot}%{_bindir}
 install -D -m 0755 bin/* %{buildroot}%{_bindir}
 install -D -m 0644 %{S:1} %{buildroot}%{_unitdir}/containerd.service

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -57,7 +57,7 @@ Source3: runc
 %if %{undefined suse_version}
 # amazonlinux2 doesn't have container-selinux either
 %if "%{?dist}" != ".amzn2"
-Requires: container-selinux >= 2:2.74
+Requires: container-selinux
 %endif
 Requires: libseccomp
 %else

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -113,7 +113,7 @@ cd %{_topdir}/BUILD/
 
 %build
 cd %{_topdir}/BUILD
-GO111MODULE=auto make man
+make man
 
 BUILDTAGS=""
 %if %{defined rhel} && 0%{?rhel} >= 8
@@ -128,14 +128,14 @@ BUILDTAGS="${BUILDTAGS} no_btrfs"
 %endif
 %endif
 
-GO111MODULE=auto make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} BUILDTAGS="${BUILDTAGS}"
+make -C /go/src/%{import_path} VERSION=%{getenv:VERSION} REVISION=%{getenv:REF} PACKAGE=%{getenv:PACKAGE} BUILDTAGS="${BUILDTAGS}"
 
 # Remove containerd-stress, as we're not shipping it as part of the packages
 rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
 
-GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin runc install
+make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin runc install
 
 
 %install


### PR DESCRIPTION
- backport https://github.com/docker/containerd-packaging/pull/361
- backport https://github.com/docker/containerd-packaging/pull/367
- backport https://github.com/docker/containerd-packaging/pull/385