### PR TITLE
feat: build Fedora 41 RPM packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ def images = [
     [image: "docker.io/library/debian:bookworm",        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (stable)
     [image: "docker.io/library/fedora:39",              arches: ["amd64", "aarch64"]],          // Fedora 39 (EOL: November 12, 2024)
     [image: "docker.io/library/fedora:40",              arches: ["amd64", "aarch64"]],          // Fedora 40 (EOL: May 13, 2025)
+    [image: "docker.io/library/fedora:41",              arches: ["amd64", "aarch64"]],          // Fedora 41 (EOL: November, 2025)
 // FIXME(thaJeztah): temporarily disabled; see https://github.com/docker/runtime-team/issues/140 and https://github.com/docker/containerd-packaging/pull/354#issuecomment-2148423969
 //     [image: "docker.io/library/fedora:rawhide",         arches: ["amd64", "aarch64"]],          // Rawhide is the name given to the current development version of Fedora
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],


### PR DESCRIPTION
**- What I did**

It's nearing that time again.  A new Fedora release.
This is part 1 of 2 for packaging Docker CE for Fedora 41.  [Part 2](https://github.com/docker/docker-ce-packaging/pull/1055) is awaiting review in the [docker/docker-ce-packaging](https://github.com/docker/docker-ce-packaging) repository.

Fedora have not (yet) set a concrete date for the EOL of Fedora 41, however it will be in or around November 2025.

**- How I did it**

I simply added a line in the Jenkinsfile to build the Fedora 41 package using the fedora:41 Docker image.

**- How to verify it**

I have successfully ran `make quay.io/fedora/fedora:41`, as described in the README.  

**- Description for the changelog**
Enable Containerd builds for Fedora 41


**- A picture of a cute animal (not mandatory but encouraged)**

![kali](https://github.com/user-attachments/assets/2c48449b-01b6-4423-a5f6-ec1dfff275a7)
