### PR TITLE
[main] Add Ubuntu 24.10 "Oracular Oriole"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ def images = [
     [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [image: "docker.io/library/ubuntu:jammy",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: April, 2027. EOL: April, 2032)
     [image: "docker.io/library/ubuntu:noble",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.04 LTS (End of support: April, 2029. EOL: April, 2034)
+    [image: "docker.io/library/ubuntu:oracular",        arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.10 (EOL: July, 2025)
 ]
 
 def generatePackageStep(opts, arch) {


### PR DESCRIPTION
Ubuntu 24.10 is planned to be released on October 10. https://discourse.ubuntu.com/t/oracular-oriole-release-schedule/36460


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add Ubuntu 24.10 "Oracular Oriole"


**- A picture of a cute animal (not mandatory but encouraged)**

