### PR TITLE
Add upcoming CentOS Stream 10.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,25 +6,26 @@
 // This list is ordered by Distro (alphabetically), and release (chronologically).
 // When adding a distro here, also open a pull request in the release repository.
 def images = [
-    [image: "docker.io/library/amazonlinux:2",          arches: ["aarch64"]],
-    [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],          // CentOS Stream 9 (EOL: 2027)
-    [image: "docker.io/library/rockylinux:8",           arches: ["amd64", "aarch64"]],          // Rocky Linux 8 (EOL: 2029-05-31)
-    [image: "docker.io/library/rockylinux:9",           arches: ["amd64", "aarch64"]],          // Rocky Linux 9 (EOL: 2032-05-31)
-    [image: "docker.io/library/almalinux:8",            arches: ["amd64", "aarch64"]],          // AlmaLinux 8 (EOL: 2029)
-    [image: "docker.io/library/almalinux:9",            arches: ["amd64", "aarch64"]],          // AlmaLinux 9 (EOL: 2032)
-    [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (EOL: 2024)
-    [image: "docker.io/library/debian:bookworm",        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (stable)
-    [image: "docker.io/library/fedora:39",              arches: ["amd64", "aarch64"]],          // Fedora 39 (EOL: November 12, 2024)
-    [image: "docker.io/library/fedora:40",              arches: ["amd64", "aarch64"]],          // Fedora 40 (EOL: May 13, 2025)
-    [image: "docker.io/library/fedora:41",              arches: ["amd64", "aarch64"]],          // Fedora 41 (EOL: November, 2025)
-    [image: "docker.io/library/fedora:rawhide",         arches: ["amd64", "aarch64"]],          // Rawhide is the name given to the current development version of Fedora
-    [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
-    [image: "docker.io/balenalib/rpi-raspbian:bullseye",arches: ["armhf"]],
-    [image: "docker.io/balenalib/rpi-raspbian:bookworm",arches: ["armhf"]],
-    [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
-    [image: "docker.io/library/ubuntu:jammy",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: April, 2027. EOL: April, 2032)
-    [image: "docker.io/library/ubuntu:noble",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.04 LTS (End of support: April, 2029. EOL: April, 2034)
-    [image: "docker.io/library/ubuntu:oracular",        arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.10 (EOL: July, 2025)
+    [image: "docker.io/library/amazonlinux:2",           arches: ["aarch64"]],
+    [image: "quay.io/centos/centos:stream9",             arches: ["amd64", "aarch64"]],          // CentOS Stream 9 (EOL: 2027)
+    [image: "quay.io/centos/centos:stream10-development",arches: ["amd64", "aarch64"]],        // CentOS Stream 10 (EOL: 2030)
+    [image: "docker.io/library/rockylinux:8",            arches: ["amd64", "aarch64"]],          // Rocky Linux 8 (EOL: 2029-05-31)
+    [image: "docker.io/library/rockylinux:9",            arches: ["amd64", "aarch64"]],          // Rocky Linux 9 (EOL: 2032-05-31)
+    [image: "docker.io/library/almalinux:8",             arches: ["amd64", "aarch64"]],          // AlmaLinux 8 (EOL: 2029)
+    [image: "docker.io/library/almalinux:9",             arches: ["amd64", "aarch64"]],          // AlmaLinux 9 (EOL: 2032)
+    [image: "docker.io/library/debian:bullseye",         arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (EOL: 2024)
+    [image: "docker.io/library/debian:bookworm",         arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (stable)
+    [image: "docker.io/library/fedora:39",               arches: ["amd64", "aarch64"]],          // Fedora 39 (EOL: November 12, 2024)
+    [image: "docker.io/library/fedora:40",               arches: ["amd64", "aarch64"]],          // Fedora 40 (EOL: May 13, 2025)
+    [image: "docker.io/library/fedora:41",               arches: ["amd64", "aarch64"]],          // Fedora 41 (EOL: November, 2025)
+    [image: "docker.io/library/fedora:rawhide",          arches: ["amd64", "aarch64"]],          // Rawhide is the name given to the current development version of Fedora
+    [image: "docker.io/opensuse/leap:15",                arches: ["amd64"]],
+    [image: "docker.io/balenalib/rpi-raspbian:bullseye", arches: ["armhf"]],
+    [image: "docker.io/balenalib/rpi-raspbian:bookworm", arches: ["armhf"]],
+    [image: "docker.io/library/ubuntu:focal",            arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
+    [image: "docker.io/library/ubuntu:jammy",            arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: April, 2027. EOL: April, 2032)
+    [image: "docker.io/library/ubuntu:noble",            arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.04 LTS (End of support: April, 2029. EOL: April, 2034)
+    [image: "docker.io/library/ubuntu:oracular",         arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.10 (EOL: July, 2025)
 ]
 
 def generatePackageStep(opts, arch) {


### PR DESCRIPTION
The release date is tentatively scheduled for 19th November 2024, so in a bit less than a month. See https://hackmd.io/@centos/Byv1EJJgJg?utm_source=preview-mode&utm_medium=rec for a draft of the future announcement.

After that date, we shall rename the OCI image tag `stream10-development` into `stream10`.

**- Description for the changelog**

Deliver containerd package for CentOS Stream 10.

