### PR TITLE
[main] Add upcoming CentOS Stream 10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@
 def images = [
     [image: "docker.io/library/amazonlinux:2",          arches: ["aarch64"]],
     [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],          // CentOS Stream 9 (EOL: 2027)
+    [image: "quay.io/centos/centos:stream10-development", arches: ["amd64", "aarch64"]],        // CentOS Stream 10 (EOL: 2030)
     [image: "docker.io/library/rockylinux:8",           arches: ["amd64", "aarch64"]],          // Rocky Linux 8 (EOL: 2029-05-31)
     [image: "docker.io/library/rockylinux:9",           arches: ["amd64", "aarch64"]],          // Rocky Linux 9 (EOL: 2032-05-31)
     [image: "docker.io/library/almalinux:8",            arches: ["amd64", "aarch64"]],          // AlmaLinux 8 (EOL: 2029)


### PR DESCRIPTION
- carry https://github.com/docker/containerd-packaging/pull/394
- closes https://github.com/docker/containerd-packaging/pull/394


> The release date is tentatively scheduled for 19th November 2024, so in a bit less than a month. See https://hackmd.io/@centos/Byv1EJJgJg?utm_source=preview-mode&utm_medium=rec for a draft of the future announcement.
> 
> After that date, we shall rename the OCI image tag `stream10-development` into `stream10`.
> 
> **- Description for the changelog**
> 
> Deliver containerd package for CentOS Stream 10.




The release date is tentatively scheduled for 19th November 2024.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

