### PR TITLE
[main] Use the final CentOS Stream 10 OCI image.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@
 def images = [
     [image: "docker.io/library/amazonlinux:2",          arches: ["aarch64"]],
     [image: "quay.io/centos/centos:stream9",            arches: ["amd64", "aarch64"]],          // CentOS Stream 9 (EOL: 2027)
-    [image: "quay.io/centos/centos:stream10-development", arches: ["amd64", "aarch64"]],        // CentOS Stream 10 (EOL: 2030)
+    [image: "quay.io/centos/centos:stream10",           arches: ["amd64", "aarch64"]],          // CentOS Stream 10 (EOL: 2030)
     [image: "docker.io/library/rockylinux:8",           arches: ["amd64", "aarch64"]],          // Rocky Linux 8 (EOL: 2029-05-31)
     [image: "docker.io/library/rockylinux:9",           arches: ["amd64", "aarch64"]],          // Rocky Linux 9 (EOL: 2032-05-31)
     [image: "docker.io/library/almalinux:8",            arches: ["amd64", "aarch64"]],          // AlmaLinux 8 (EOL: 2029)


### PR DESCRIPTION
@thaJeztah Yesterday RHEL 10 Beta was officially released, and it seems at the same time Red Hat has renamed the CentOS Stream 10 image name to it's final name. See https://quay.io/repository/centos/centos?tab=tags&tag=latest