### PR TITLE
[main] rpm: use SPDX identifier for License field

### DIFF
--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -47,7 +47,7 @@ Conflicts: runc
 Version: %{getenv:RPM_VERSION}
 Release: %{getenv:RPM_RELEASE_VERSION}%{?dist}
 Summary: An industry-standard container runtime
-License: ASL 2.0
+License: Apache-2.0
 URL: https://containerd.io
 Source0: containerd
 Source1: containerd.service


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/issues/1112
- relates to https://github.com/docker/docker-ce-packaging/pull/1135



Update the license fields to use the (now recommented) SPDX identifier;

> https://docs.fedoraproject.org/en-US/legal/allowed-licenses/ lists
> Apache-2.0 as the SPDX identifier and ASL 2.0 as a "Legacy Abbreviation"
> for Apache License 2.0.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

