### PR TITLE
Add Fedora 42.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ def images = [
     [image: "docker.io/library/debian:trixie",          arches: ["amd64", "aarch64", "armhf"]], // Debian 13 (testing)
     [image: "docker.io/library/fedora:40",              arches: ["amd64", "aarch64"]],          // Fedora 40 (EOL: May 13, 2025)
     [image: "docker.io/library/fedora:41",              arches: ["amd64", "aarch64"]],          // Fedora 41 (EOL: November, 2025)
+    [image: "docker.io/library/fedora:42",              arches: ["amd64", "aarch64"]],          // Fedora 42 (EOL: May 13, 2026)
     [image: "docker.io/library/fedora:rawhide",         arches: ["amd64", "aarch64"]],          // Rawhide is the name given to the current development version of Fedora
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
     [image: "docker.io/balenalib/rpi-raspbian:bullseye",arches: ["armhf"]],


### PR DESCRIPTION
Fedora 42 is in beta freeze, and the beta will be released around 11th of March. It should now be "stable" enough to add it to your regular builds and deliveries.

Locally I was able to test (with podman and couple of modifications, I don't have docker on my development machine) that ` make quay.io/fedora/fedora:42` seems to run till the end.