### PR TITLE
prepare release 1.7.26

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (1.7.26-1) release; urgency=medium
+
+  * Update containerd binary to v1.7.26
+  * Update runc binary to v1.2.5
+
+ -- Paweł Gronowski <pawel.gronowski@docker.com>  Wed, 12 Mar 2025 18:31:31 +0000
+
 containerd.io (1.7.25-1) release; urgency=medium
 
   * Update containerd binary to v1.7.25

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -159,6 +159,10 @@ done
 
 
 %changelog
+* Wed Mar 12 2025 Paweł Gronowski <pawel.gronowski@docker.com> - 1.7.26-3.1
+- Update containerd binary to v1.7.26
+- Update runc binary to v1.2.5
+
 * Fri Jan 10 2025 Paweł Gronowski <pawel.gronowski@docker.com> - 1.7.25-3.1
 - Update containerd binary to v1.7.25
 - Update runc binary to v1.2.4


### PR DESCRIPTION
- Update containerd binary to v1.7.26
- Update runc binary to v1.2.5

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>