### PR TITLE
Makefile: Switch to github.com/containerd/ltag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,4 +114,4 @@ build:
 
 .PHONY: validate
 validate: ## Validate files license header
-	docker run --rm -v $(CURDIR):/work -w /work golang:alpine sh -c 'go install github.com/kunalkushwaha/ltag@latest && ./scripts/validate/fileheader'
+	docker run --rm -v $(CURDIR):/work -w /work golang:alpine sh -c 'go install github.com/containerd/ltag@latest && ./scripts/validate/fileheader'


### PR DESCRIPTION
v0.2.6 was the last version the module was named github.com/kunalkushwaha/ltag.

Update to github.com/containerd/ltag
