### PR TITLE
windows: set git save-path to fix "dubious permissions" on bind-mounts

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -45,9 +45,9 @@ build/windows/%.exe: windows-image
 	Powershell.exe New-Item -ItemType Directory -Force -Path build/windows/
 	docker run \
 		--rm \
-		-v "$(CURDIR)/src/:C:/gopath/src" \
-		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
-		-w "C:/gopath/src/github.com/containerd/containerd" \
+		-v "$(CURDIR)/src/:c:/src" \
+		-v "$(CURDIR)/build/windows:c:/src/github.com/containerd/containerd/bin" \
+		-w "c:/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
 		make bin/$*
 

--- a/dockerfiles/win.dockerfile
+++ b/dockerfiles/win.dockerfile
@@ -22,3 +22,8 @@ RUN  iex ((new-object net.webclient).DownloadString('https://chocolatey.org/inst
      choco feature disable --name showDownloadProgress; \
      choco install -y make; \
      choco install -y mingw --version 10.2.0 --allow-downgrade
+
+# Set safe git directory to prevent "dubious ownership" errors
+# when bind-mounting the source into the dev-container.
+# See https://github.com/moby/moby/pull/44930 and https://github.com/docker/containerd-packaging/pull/412
+RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

