### PR TITLE
Fix Windows packaging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ def packageBuildSteps = [
     }
 ]
 
-packageBuildSteps << images.collectEntries { generatePackageSteps(it) }
+// packageBuildSteps << images.collectEntries { generatePackageSteps(it) }
 
 pipeline {
     agent none

--- a/Makefile.win
+++ b/Makefile.win
@@ -52,7 +52,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
 		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
-		powershell.exe '$env:GIT_TRACE2 = "1"; git status'
+		powershell.exe '\$env:GIT_TRACE2 = "1"; git status'
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -38,6 +38,7 @@ checkout: src
 windows-image: checkout
 	docker build \
 		--pull \
+		--no-cache \
 		--build-arg GOLANG_IMAGE=$(GOLANG_IMAGE) \
 		-t dockereng/containerd-windows-builder \
 		-f dockerfiles/win.dockerfile \

--- a/Makefile.win
+++ b/Makefile.win
@@ -46,7 +46,7 @@ windows-image: checkout
 
 build/windows/%.exe: windows-image
 	Powershell.exe New-Item -ItemType Directory -Force -Path build/windows/
-	docker run --rm -v "$(CURDIR)/src/:C:/gopath/src" -v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" -w "C:/gopath/src/github.com/containerd/containerd" dockereng/containerd-windows-builder cmd.exe /S /C "dir && make -d bin/$*"
+	docker run --rm -v "$(CURDIR)/src/:C:/gopath/src" -v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" -w "C:/gopath/src/github.com/containerd/containerd" dockereng/containerd-windows-builder cmd.exe /S /C "                         dir && make -d bin/$*"
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -52,7 +52,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
 		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
-		powershell.exe '\$env:GIT_TRACE2 = "1"; git status'
+		powershell.exe '$$env:GIT_TRACE2 = "1"; git status'
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -46,6 +46,7 @@ windows-image: checkout
 
 build/windows/%.exe: windows-image
 	Powershell.exe New-Item -ItemType Directory -Force -Path build/windows/
+	Powershell.exe Get-ChildItem -Path "$(CURDIR)/src/github.com/containerd/containerd"
 	docker run \
 		--rm \
 		-v "$(CURDIR)/src/:C:/gopath/src" \

--- a/Makefile.win
+++ b/Makefile.win
@@ -28,6 +28,8 @@ endif
 
 .PHONY: checkout
 checkout: src
+	echo  GIT VERSION
+	git version
 	@git -C src/github.com/containerd/containerd fetch --depth 1 origin "$(REF)"
 	@git -C src/github.com/containerd/containerd checkout -q FETCH_HEAD
 	@git -C src/github.com/containerd/containerd config --add safe.directory C:/gopath/src/github.com/containerd/containerd

--- a/Makefile.win
+++ b/Makefile.win
@@ -46,7 +46,7 @@ windows-image: checkout
 
 build/windows/%.exe: windows-image
 	Powershell.exe New-Item -ItemType Directory -Force -Path build/windows/
-	Powershell.exe Get-ChildItem -Path "$(CURDIR)/src/github.com/containerd/containerd"
+	Powershell.exe Get-ChildItem -Force -Path "$(CURDIR)/src/github.com/containerd/containerd"
 	Powershell.exe Get-ChildItem -Path "$(CURDIR)/src/github.com/containerd/containerd/.git"
 	Powershell.exe Get-ChildItem -Path ".git"
 	docker run \
@@ -55,7 +55,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
 		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
-		powershell.exe Get-ChildItem
+		powershell.exe Get-ChildItem -Force
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -52,7 +52,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
 		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
-		make -d bin/$*
+		cmd.exe /S /C "dir && make -d bin/$*"
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -30,6 +30,7 @@ endif
 checkout: src
 	@git -C src/github.com/containerd/containerd fetch --depth 1 origin "$(REF)"
 	@git -C src/github.com/containerd/containerd checkout -q FETCH_HEAD
+	@git -C src/github.com/containerd/containerd config --add safe.directory C:/gopath/src/github.com/containerd/containerd
 
 # Windows builder, only difference is we installed make
 windows-image: checkout

--- a/Makefile.win
+++ b/Makefile.win
@@ -52,7 +52,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
 		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
-		powershell.exe '$$env:GIT_TRACE2 = "1"; git status'
+		powershell.exe '$$env:GIT_TRACE2 = "1"; git status; git version; git diff --no-ext-diff; make -d bin/$*'
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -46,7 +46,13 @@ windows-image: checkout
 
 build/windows/%.exe: windows-image
 	Powershell.exe New-Item -ItemType Directory -Force -Path build/windows/
-	docker run --rm -v "$(CURDIR)/src/:C:/gopath/src" -v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" -w "C:/gopath/src/github.com/containerd/containerd" dockereng/containerd-windows-builder cmd.exe /C "dir && make -d bin/$*"
+	docker run \
+		--rm \
+		-v "$(CURDIR)/src/:C:/gopath/src" \
+		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
+		-w "C:/gopath/src/github.com/containerd/containerd" \
+		dockereng/containerd-windows-builder \
+		cmd.exe /C dir "&&" make -d bin/$*
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -52,7 +52,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
 		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
-		powershell.exe "Get-ChildItem -Force; make -d bin/$*"
+		powershell.exe '$env:GIT_TRACE2 = "1"; git status'
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -47,6 +47,8 @@ windows-image: checkout
 build/windows/%.exe: windows-image
 	Powershell.exe New-Item -ItemType Directory -Force -Path build/windows/
 	Powershell.exe Get-ChildItem -Path "$(CURDIR)/src/github.com/containerd/containerd"
+	Powershell.exe Get-ChildItem -Path "$(CURDIR)/src/github.com/containerd/containerd/.git"
+	Powershell.exe Get-ChildItem -Path ".git"
 	docker run \
 		--rm \
 		-v "$(CURDIR)/src/:C:/gopath/src" \

--- a/Makefile.win
+++ b/Makefile.win
@@ -52,7 +52,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
 		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
-		powershell.exe '$$env:GIT_TRACE2 = "1"; git status; git version; git diff --no-ext-diff; make -d bin/$*'
+		powershell.exe '$$env:GIT_TRACE2 = "1"; make REVISION=$$(git rev-parse HEAD) -d bin/$*'
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -52,7 +52,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
 		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
-		cmd.exe /C dir "&&" make -d bin/$*
+		powershell.exe Get-ChildItem
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -46,13 +46,7 @@ windows-image: checkout
 
 build/windows/%.exe: windows-image
 	Powershell.exe New-Item -ItemType Directory -Force -Path build/windows/
-	docker run \
-		--rm \
-		-v "$(CURDIR)/src/:C:/gopath/src" \
-		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
-		-w "C:/gopath/src/github.com/containerd/containerd" \
-		dockereng/containerd-windows-builder \
-		cmd.exe /S /C "dir && make -d bin/$*"
+	docker run --rm -v "$(CURDIR)/src/:C:/gopath/src" -v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" -w "C:/gopath/src/github.com/containerd/containerd" dockereng/containerd-windows-builder cmd.exe /S /C "dir && make -d bin/$*"
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -52,7 +52,7 @@ build/windows/%.exe: windows-image
 		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
 		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
-		make bin/$*
+		make -d bin/$*
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -46,7 +46,7 @@ windows-image: checkout
 
 build/windows/%.exe: windows-image
 	Powershell.exe New-Item -ItemType Directory -Force -Path build/windows/
-	docker run --rm -v "$(CURDIR)/src/:C:/gopath/src" -v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" -w "C:/gopath/src/github.com/containerd/containerd" dockereng/containerd-windows-builder cmd.exe /S /C "                         dir && make -d bin/$*"
+	docker run --rm -v "$(CURDIR)/src/:C:/gopath/src" -v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" -w "C:/gopath/src/github.com/containerd/containerd" dockereng/containerd-windows-builder cmd.exe /C "dir && make -d bin/$*"
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/Makefile.win
+++ b/Makefile.win
@@ -46,16 +46,13 @@ windows-image: checkout
 
 build/windows/%.exe: windows-image
 	Powershell.exe New-Item -ItemType Directory -Force -Path build/windows/
-	Powershell.exe Get-ChildItem -Force -Path "$(CURDIR)/src/github.com/containerd/containerd"
-	Powershell.exe Get-ChildItem -Path "$(CURDIR)/src/github.com/containerd/containerd/.git"
-	Powershell.exe Get-ChildItem -Path ".git"
 	docker run \
 		--rm \
 		-v "$(CURDIR)/src/:C:/gopath/src" \
 		-v "$(CURDIR)/build/windows:C:/gopath/src/github.com/containerd/containerd/bin" \
 		-w "C:/gopath/src/github.com/containerd/containerd" \
 		dockereng/containerd-windows-builder \
-		powershell.exe Get-ChildItem -Force
+		powershell.exe "Get-ChildItem -Force; make -d bin/$*"
 
 build/windows/containerd.zip: build/windows/containerd.exe build/windows/ctr.exe
 	Powershell.exe Compress-Archive -Force -Path 'build/windows/*.exe' -DestinationPath '$@'

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -75,7 +75,7 @@ FROM redhat-base AS fedora-base
 # - https://src.fedoraproject.org/rpms/golang/c/a867bd88a656c1d6e91e7b18bab696dc3fcf1e77?branch=rawhide
 #
 # As a workaround; install binutils-gold
-RUN if [ "$(arch)" = 'aarch64' ] && [ $(source /etc/os-release && echo "${VERSION_ID%.*}") -ge 41 ]; then dnf -y install binutils-gold; fi
+RUN if [ "$(rpm --query --queryformat='%{ARCH}' rpm)" = 'aarch64' ] && [ $(source /etc/os-release && echo "${VERSION_ID%.*}") -ge 41 ]; then dnf -y install binutils-gold; fi
 
 FROM ${BUILD_IMAGE} AS amzn-base
 RUN yum install -y yum-utils rpm-build git

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -74,8 +74,8 @@ FROM redhat-base AS fedora-base
 # - https://src.fedoraproject.org/rpms/golang/blob/a867bd88a656c1d6e91e7b18bab696dc3fcf1e77/f/0006-Default-to-ld.bfd-on-ARM64.patch
 # - https://src.fedoraproject.org/rpms/golang/c/a867bd88a656c1d6e91e7b18bab696dc3fcf1e77?branch=rawhide
 #
-# As a workaround; install binutils-gold
-RUN if [ "$(rpm --query --queryformat='%{ARCH}' rpm)" = 'aarch64' ] && [ $(source /etc/os-release && echo "${VERSION_ID%.*}") -ge 41 ]; then dnf -y install binutils-gold; fi
+# As a workaround; install binutils-gold if it's not installed
+RUN if [ "$(rpm --query --queryformat='%{ARCH}' rpm)" = 'aarch64' ] && ! command -v ld.gold; then dnf -y install binutils-gold; fi
 
 FROM ${BUILD_IMAGE} AS amzn-base
 RUN yum install -y yum-utils rpm-build git

--- a/dockerfiles/win.dockerfile
+++ b/dockerfiles/win.dockerfile
@@ -22,3 +22,5 @@ RUN  iex ((new-object net.webclient).DownloadString('https://chocolatey.org/inst
      choco feature disable --name showDownloadProgress; \
      choco install -y make; \
      choco install -y mingw --version 10.2.0 --allow-downgrade
+
+RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
Adds the containerd path to safe directories to address the "dubious
ownership" error when building containerd in Windows container:

```
fatal: detected dubious ownership in repository at 'C:/gopath/src/github.com/containerd/containerd'

'C:/gopath/src/github.com/containerd/containerd' is owned by:

	NT AUTHORITY/SYSTEM (S-1-5-18)

but the current user is:

	User Manager/ContainerAdministrator (S-1-5-93-2-1)
```
