### PR TITLE
Fix shell script vulnerabilities

### DIFF
--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -56,5 +56,5 @@ checkout() (
 # Only execute checkout function above if this file is executed, not sourced from another script
 prog=checkout.sh # needs to be in sync with this file's name
 if [ "$(basename -- $0)" = "$prog" ]; then
-	checkout $*
+	checkout "$@"
 fi

--- a/scripts/validate/fileheader
+++ b/scripts/validate/fileheader
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-set -eu -o
+set -eu -o pipefail
 
 if ! command -v ltag; then
 	echo >&2 "ERROR: ltag not found. Install with:"


### PR DESCRIPTION
**- What I did**

Fixed two shell script vulnerabilities that could lead to unexpected behavior.

**- How I did it**

- Added the missing `pipefail` argument to the `-o` flag in `scripts/validate/fileheader`
- Changed `checkout $*` to `checkout "$@"` in `scripts/checkout.sh` to properly handle arguments with spaces

**- How to verify it**

- Test the validate script to ensure it behaves correctly on pipeline failures
- Test the checkout script with arguments containing spaces to verify they are handled correctly

**- Description for the changelog**

Fixed shell script vulnerabilities in validate/fileheader and checkout.sh scripts.
