### PR TITLE
remove ubuntu 20.04 "focal", as it reached EOL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,6 @@ def images = [
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
     [image: "docker.io/balenalib/rpi-raspbian:bullseye",arches: ["armhf"]],
     [image: "docker.io/balenalib/rpi-raspbian:bookworm",arches: ["armhf"]],
-    [image: "docker.io/library/ubuntu:focal",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [image: "docker.io/library/ubuntu:jammy",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: April, 2027. EOL: April, 2032)
     [image: "docker.io/library/ubuntu:noble",           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.04 LTS (End of support: April, 2029. EOL: April, 2034)
     [image: "docker.io/library/ubuntu:oracular",        arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.10 (EOL: July, 2025)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 include common/common.mk
 
 ARCH=$(shell uname -m)
-BUILD_IMAGE=ubuntu:focal
+BUILD_IMAGE=ubuntu:noble
 BUILD_TYPE=$(shell ./scripts/deb-or-rpm $(BUILD_IMAGE))
 BUILD_BASE=$(shell ./scripts/determine-base $(BUILD_IMAGE))
 

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG BUILD_IMAGE=ubuntu:focal
+ARG BUILD_IMAGE=ubuntu:noble
 ARG GOLANG_IMAGE=golang:latest
 
 # Install golang from the official image, since the package managed


### PR DESCRIPTION
Ubuntu 20.04 reached end of support on April 30. There's still commercial ESM (Extended Security Maintenance) support, but we don't account for that in our packages; https://ubuntu.com/blog/ubuntu-20-04-eol-for-devicesional

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

