### PR TITLE
remove Fedora 40 (EOL)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@ def images = [
     [image: "docker.io/library/debian:bullseye",        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (oldstable, EOL: 2024-08-14, EOL (LTS): 2026-08-31)
     [image: "docker.io/library/debian:bookworm",        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (stable, EOL: 2026-06-10, EOL (LTS): 2028-06-30)
     [image: "docker.io/library/debian:trixie",          arches: ["amd64", "aarch64", "armhf"]], // Debian 13 (testing)
-    [image: "docker.io/library/fedora:40",              arches: ["amd64", "aarch64"]],          // Fedora 40 (EOL: May 13, 2025)
     [image: "docker.io/library/fedora:41",              arches: ["amd64", "aarch64"]],          // Fedora 41 (EOL: November, 2025)
     [image: "docker.io/library/fedora:42",              arches: ["amd64", "aarch64"]],          // Fedora 42 (EOL: May 13, 2026)
     [image: "docker.io/library/fedora:rawhide",         arches: ["amd64", "aarch64"]],          // Rawhide is the name given to the current development version of Fedora


### PR DESCRIPTION
Fedora 40 reached EOL on May 13, 2025;
https://docs.fedoraproject.org/en-US/releases/eol/


**- A picture of a cute animal (not mandatory but encouraged)**

