### PR TITLE
Use SOURCE_DATE_EPOCH to improve reproducibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ BUILD_BASE=$(shell ./scripts/determine-base $(BUILD_IMAGE))
 PROGRESS=auto
 TARGET=packages
 
+# SOURCE_DATE_EPOCH is set to make builds reproducible that would otherwise be
+# different due solely to file mtimes and derived changelog entries. It is set
+# to the most recent modification timestamp of all repos under src/. The rpm
+# and deb packaging toolchains support this variable.
+SOURCE_DATE_EPOCH=$(shell ./scripts/source-date-epoch src/)
+
 all: build
 
 .PHONY: clean
@@ -106,6 +112,7 @@ build:
 		--build-arg CREATE_ARCHIVE="$(CREATE_ARCHIVE)" \
 		--build-arg UID="$(shell id -u)" \
 		--build-arg GID="$(shell id -g)" \
+		--build-arg SOURCE_DATE_EPOCH="$(SOURCE_DATE_EPOCH)" \
 		--file="dockerfiles/$(BUILD_TYPE).dockerfile" \
 		--progress="$(PROGRESS)" \
 		--target="$(TARGET)" \

--- a/dockerfiles/deb.dockerfile
+++ b/dockerfiles/deb.dockerfile
@@ -117,6 +117,7 @@ FROM build-env AS build-packages
 RUN mkdir -p /archive /build
 COPY common/containerd.service common/containerd.toml /root/common/
 ARG CREATE_ARCHIVE
+ARG SOURCE_DATE_EPOCH
 # NOTE: not using a cache-mount for /root/.cache/go-build, to prevent issues
 #       with CGO when building multiple distros on the same machine / build-cache
 RUN --mount=type=bind,from=golang,source=/usr/local/go/,target=/usr/local/go/ \

--- a/dockerfiles/rpm.dockerfile
+++ b/dockerfiles/rpm.dockerfile
@@ -116,6 +116,7 @@ FROM build-env AS build-packages
 RUN mkdir -p /archive /build
 COPY common/containerd.service common/containerd.toml SOURCES/
 ARG CREATE_ARCHIVE
+ARG SOURCE_DATE_EPOCH
 # NOTE: not using a cache-mount for /root/.cache/go-build, to prevent issues
 #       with CGO when building multiple distros on the same machine / build-cache
 RUN --mount=type=bind,from=golang,source=/usr/local/go/,target=/usr/local/go/ \

--- a/scripts/build-deb
+++ b/scripts/build-deb
@@ -22,7 +22,9 @@ set -e
 VERSION="$(git --git-dir "${GO_SRC_PATH}/.git" describe --tags | sed 's/^v//')"
 # Check if we're on a tagged version, change VERSION to dev build if not
 if ! git --git-dir "${GO_SRC_PATH}/.git" describe --exact-match HEAD > /dev/null 2>&1; then
-	git_date=$(TZ=UTC date --date "@$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%at')" +'%Y%m%d.%H%M%S')
+	git_timestamp=$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%at')
+	git_date=$(TZ=UTC date --date "@${git_timestamp}" +'%Y%m%d.%H%M%S')
+	git_rfc2822=$(TZ=UTC date --date "@${git_timestamp}" --rfc-2822)
 	git_sha=$(git --git-dir "${GO_SRC_PATH}/.git" log -1 --pretty='%h')
 	VERSION="${git_date}~${git_sha}"
 	# prepend a `0` so it'll never be greater than non-dev versions
@@ -31,7 +33,7 @@ if ! git --git-dir "${GO_SRC_PATH}/.git" describe --exact-match HEAD > /dev/null
 
 		  * Release for ${git_sha}
 
-		 -- $(control_field Maintainer)  $(TZ=UTC date --rfc-2822)
+		 -- $(control_field Maintainer)  ${git_rfc2822}
 
 	EOF
 	cat debian/changelog >> debian/nightly.changelog

--- a/scripts/build-rpm
+++ b/scripts/build-rpm
@@ -61,7 +61,10 @@ ARCH="$(uname -m)"
 DEST_DIR="/build/${DIST_ID}/${DIST_VERSION}/${ARCH}/"
 (
 	set -x
-	rpmbuild -ba "${SPEC_FILE}"
+	rpmbuild -ba "${SPEC_FILE}" \
+		-D "want_reproducible_builds 1" \
+		-D "build_mtime_policy clamp_to_source_date_epoch" \
+		-D "use_source_date_epoch_as_buildtime 1"
 	mkdir -p "${DEST_DIR}"
 	mv -v RPMS/*/*.rpm "${DEST_DIR}"
 	mv -v SRPMS/*.rpm "${DEST_DIR}"

--- a/scripts/source-date-epoch
+++ b/scripts/source-date-epoch
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+#   Copyright 2018-2022 Docker Inc.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Find the most recent modification timestamp of repos under the given
+# directory.
+SRC="$1"
+
+find "$SRC" -type d -name .git \
+	-exec git log -1 --pretty=%ct -C \; \
+	| sort -rn | head -n 1


### PR DESCRIPTION
Set `SOURCE_DATE_EPOCH` to the most recent modification timestamp of all repos under `src/`. This allows deb and rpm toolchains to clamp mtimes and better reproduce packages that would otherwise be different due solely to the current time.

See https://reproducible-builds.org/docs/source-date-epoch/ for a recommended approaches to setting this variable and a list of supported tooling.

Note that this was developed while testing a fix to #303 but it does not address that issue directly as compiled binaries still differ between Debian releases.

**- What I did**

Introduced a `SOURCE_DATE_EPOCH` build argument to make package builds more reproducible. Support varies by package build tool.

**- How I did it**

Defined a new `SOURCE_DATE_EPOCH` build arg and set it to the most recent modification timestamp of all respos under `src/`. 

**- How to verify it**

 1. Start with a fresh build cache (e.g. `docker buildx prune`) and build directory (`rm -rf build/*`).
 2. Build the trixie deb with `make REF=v1.7.27 PROGRESS=plain ARCH=amd64 docker.io/library/debian:trixie`
 3. Copy the results to a temporary location (e.g. `cp -a build build1`).
 4. Repeat steps 1 and 2 to clear the cache and build directory again and rebuild the packages.
 5. Compare the two build directories (`diff -r build build1`). They should be identical.

**- Description for the changelog**

Improved package reproducibility by clamping mtimes with `SOURCE_DATE_EPOCH`.
