### PR TITLE
deb: Use a distro specific suffix in deb version

### DIFF
--- a/scripts/build-deb
+++ b/scripts/build-deb
@@ -19,6 +19,14 @@
 
 set -e
 
+DIST_ID="$(. /etc/os-release; echo "${ID}")"
+DIST_VERSION=$(lsb_release -sc)
+DIST_VERSION_ID="$(. /etc/os-release; echo "${VERSION_ID}")"
+
+# Append the version with distro information to match docker-ce packaging
+# See https://github.com/docker/docker-ce-packaging/blob/master/deb/build-deb
+DEB_SUFFIX="~${DIST_ID}.${DIST_VERSION_ID}~${DIST_VERSION}"
+
 VERSION="$(git --git-dir "${GO_SRC_PATH}/.git" describe --tags | sed 's/^v//')"
 # Check if we're on a tagged version, change VERSION to dev build if not
 if ! git --git-dir "${GO_SRC_PATH}/.git" describe --exact-match HEAD > /dev/null 2>&1; then
@@ -27,7 +35,7 @@ if ! git --git-dir "${GO_SRC_PATH}/.git" describe --exact-match HEAD > /dev/null
 	VERSION="${git_date}~${git_sha}"
 	# prepend a `0` so it'll never be greater than non-dev versions
 	cat > debian/nightly.changelog <<- EOF
-		$(control_field Package) (0.${VERSION}-1) development; urgency=medium
+		$(control_field Package) (0.${VERSION}-1${DEB_SUFFIX}) development; urgency=medium
 
 		  * Release for ${git_sha}
 
@@ -37,6 +45,8 @@ if ! git --git-dir "${GO_SRC_PATH}/.git" describe --exact-match HEAD > /dev/null
 	cat debian/changelog >> debian/nightly.changelog
 	cat debian/nightly.changelog
 	mv debian/nightly.changelog debian/changelog
+else
+	sed -i "1 s/) release;/${DEB_SUFFIX}) release;/" debian/changelog
 fi
 
 REF=$(git --git-dir "${GO_SRC_PATH}/.git" rev-parse HEAD)
@@ -48,8 +58,6 @@ export VERSION
 	dpkg-buildpackage -uc -us
 )
 
-DIST_ID="$(. /etc/os-release; echo "${ID}")"
-DIST_VERSION=$(lsb_release -sc)
 ARCH=$(dpkg --print-architecture)
 DEST_DIR="/build/${DIST_ID}/${DIST_VERSION}/${ARCH}/"
 mkdir -p "${DEST_DIR}"


### PR DESCRIPTION
Append the version in the latest `debian/changelog` entry with a distro specific suffix just before packing. This matches the convention used by docker-ce packages.

See https://github.com/docker/docker-ce-packaging/blob/master/deb/build-deb

Fixes #303 allowing repository maintainers to import packages for multiple distros and distro versions without package conflicts.

**- What I did**

* See commit message.

**- How I did it**

* Modified `scripts/build-deb` to append the version just prior to `dpkg-buildpackage`.
* Note that I first attempted to use `dch` but it proved too fussy and required changes to your `scripts/new-deb-version` script as well. I didn't want to mess with your release workflow too much. :smile: 

**- How to verify it**

* Build a deb and verify that its version contains the distro specific suffix.

```console
$ make REF=v1.7.27 ARCH=amd64 docker.io/library/debian:trixie
make BUILD_IMAGE="docker.io/library/debian:trixie" build
make[1]: Entering directory '/home/dduvall/src/github.com/docker/containerd-packaging'
./scripts/checkout.sh src/github.com/containerd/containerd "v1.7.27"
[...]
$ dpkg-deb -W build/debian/trixie/amd64/containerd.io_1.7.27-1~debian.13~trixie_amd64.deb 
containerd.io   1.7.27-1~debian.13~trixie
```

**- Description for the changelog**

Append distro suffixes (`~{distro}.{distro-version}~{codename}`) to deb packages to match docker-ce package conventions.

**- A picture of a cute animal (not mandatory but encouraged)**

:dog: 
