### PR TITLE
prepare release v2.1.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd.io (2.1.4-1) release; urgency=medium
+
+  * Update containerd binary to v2.1.4
+  * Update runc binary to v1.3.0
+
+ -- CL0Pinette <me@cl0pinette.fr>  Fri, 29 Aug 2025 12:12:57 +0000
+
 containerd.io (1.7.27-1) release; urgency=medium
 
   * Update containerd binary to v1.7.27

--- a/rpm/containerd.spec
+++ b/rpm/containerd.spec
@@ -159,6 +159,10 @@ done
 
 
 %changelog
+* Fri Aug 29 2025 CL0Pinette <me@cl0pinette.fr> - 2.1.4-3.1
+- Update containerd binary to v2.1.4
+- Update runc binary to v1.3.0
+
 * Mon Mar 31 2025 Paweł Gronowski <pawel.gronowski@docker.com> - 1.7.27-3.1
 - Update containerd binary to v1.7.27
 


### PR DESCRIPTION
- Update containerd binary to v2.1.4
- Update runc binary to v1.3.0


After the release of kubernetes 1.34, they anounced that containerd 1.7.X would not be supported anymore beginning with kubernetes 1.36.
However, no containerd 2.X.Y versions are available on Debian repositories, not even on trixie which was released 3 weeks ago.
As this repository is the major one distributing containerd, I think it would be important to support containerd 2.X.Y.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**