### PR TITLE
Add Fedora 43.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ def images = [
     [image: "docker.io/library/debian:trixie",          arches: ["amd64", "aarch64", "armhf"]], // Debian 13 (testing)
     [image: "docker.io/library/fedora:41",              arches: ["amd64", "aarch64"]],          // Fedora 41 (EOL: November, 2025)
     [image: "docker.io/library/fedora:42",              arches: ["amd64", "aarch64"]],          // Fedora 42 (EOL: May 13, 2026)
+    [image: "docker.io/library/fedora:43",              arches: ["amd64", "aarch64"]],          // Fedora 43 (EOL: December 02, 2026)
     [image: "docker.io/library/fedora:rawhide",         arches: ["amd64", "aarch64"]],          // Rawhide is the name given to the current development version of Fedora
     [image: "docker.io/opensuse/leap:15",               arches: ["amd64"]],
     [image: "docker.io/balenalib/rpi-raspbian:bullseye",arches: ["armhf"]],


### PR DESCRIPTION
Add Fedora 43 in the CI list. The beta of fedora 43 is expected next week, and the final release is expected end of october/november.